### PR TITLE
[BACKEND] Domain - Crear Entidad ProcessingJob

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/domain/exception/InvalidStatusTransitionException.java
+++ b/backend/src/main/java/com/scalevision/backend/domain/exception/InvalidStatusTransitionException.java
@@ -1,0 +1,10 @@
+package com.scalevision.backend.domain.exception;
+
+import com.scalevision.backend.domain.model.JobStatus;
+
+public class InvalidStatusTransitionException extends RuntimeException {
+
+    public InvalidStatusTransitionException(JobStatus currentStatus, JobStatus nextStatus) {
+        super("Invalid status transition: " + currentStatus + " -> " + nextStatus);
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/domain/model/JobStatus.java
+++ b/backend/src/main/java/com/scalevision/backend/domain/model/JobStatus.java
@@ -1,0 +1,8 @@
+package com.scalevision.backend.domain.model;
+
+public enum JobStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java
+++ b/backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java
@@ -1,0 +1,116 @@
+package com.scalevision.backend.domain.model;
+
+import com.scalevision.backend.domain.exception.InvalidStatusTransitionException;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+public class ProcessingJob {
+
+    private final UUID id;
+    private final String videoUrl;
+    private final String targetAspectRatio;
+    private final Integer targetDuration;
+    private final String focusArea;
+    private JobStatus status;
+    private String aiTaskId;
+    private String outputUrl;
+    private String errorMessage;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public ProcessingJob(
+            UUID id,
+            String videoUrl,
+            String targetAspectRatio,
+            Integer targetDuration,
+            String focusArea
+    ) {
+        this.id = Objects.requireNonNull(id, "id is required");
+        this.videoUrl = Objects.requireNonNull(videoUrl, "videoUrl is required");
+        this.targetAspectRatio = targetAspectRatio;
+        this.targetDuration = targetDuration;
+        this.focusArea = focusArea;
+        this.status = JobStatus.PENDING;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    public boolean canTransitionTo(JobStatus nextStatus) {
+        Objects.requireNonNull(nextStatus, "nextStatus is required");
+
+        return switch (this.status) {
+            case PENDING -> nextStatus == JobStatus.PROCESSING || nextStatus == JobStatus.FAILED;
+            case PROCESSING -> nextStatus == JobStatus.COMPLETED || nextStatus == JobStatus.FAILED;
+            case COMPLETED, FAILED -> false;
+        };
+    }
+
+    public void updateStatus(JobStatus nextStatus) {
+        if (!canTransitionTo(nextStatus)) {
+            throw new InvalidStatusTransitionException(this.status, nextStatus);
+        }
+        this.status = nextStatus;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getVideoUrl() {
+        return videoUrl;
+    }
+
+    public String getTargetAspectRatio() {
+        return targetAspectRatio;
+    }
+
+    public Integer getTargetDuration() {
+        return targetDuration;
+    }
+
+    public String getFocusArea() {
+        return focusArea;
+    }
+
+    public JobStatus getStatus() {
+        return status;
+    }
+
+    public String getAiTaskId() {
+        return aiTaskId;
+    }
+
+    public void setAiTaskId(String aiTaskId) {
+        this.aiTaskId = aiTaskId;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public String getOutputUrl() {
+        return outputUrl;
+    }
+
+    public void setOutputUrl(String outputUrl) {
+        this.outputUrl = outputUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java
+++ b/backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java
@@ -3,7 +3,6 @@ package com.scalevision.backend.domain.model;
 import com.scalevision.backend.domain.exception.InvalidStatusTransitionException;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 import java.util.UUID;
 
 public class ProcessingJob {
@@ -27,8 +26,15 @@ public class ProcessingJob {
             Integer targetDuration,
             String focusArea
     ) {
-        this.id = Objects.requireNonNull(id, "id is required");
-        this.videoUrl = Objects.requireNonNull(videoUrl, "videoUrl is required");
+        if (id == null) {
+            throw new IllegalArgumentException("id is required");
+        }
+        if (videoUrl == null || videoUrl.isBlank()) {
+            throw new IllegalArgumentException("videoUrl is required");
+        }
+
+        this.id = id;
+        this.videoUrl = videoUrl;
         this.targetAspectRatio = targetAspectRatio;
         this.targetDuration = targetDuration;
         this.focusArea = focusArea;
@@ -38,13 +44,17 @@ public class ProcessingJob {
     }
 
     public boolean canTransitionTo(JobStatus nextStatus) {
-        Objects.requireNonNull(nextStatus, "nextStatus is required");
+        if (nextStatus == null) {
+            return false;
+        }
 
-        return switch (this.status) {
-            case PENDING -> nextStatus == JobStatus.PROCESSING || nextStatus == JobStatus.FAILED;
-            case PROCESSING -> nextStatus == JobStatus.COMPLETED || nextStatus == JobStatus.FAILED;
-            case COMPLETED, FAILED -> false;
-        };
+        if (this.status == JobStatus.PENDING) {
+            return nextStatus == JobStatus.PROCESSING || nextStatus == JobStatus.FAILED;
+        }
+        if (this.status == JobStatus.PROCESSING) {
+            return nextStatus == JobStatus.COMPLETED || nextStatus == JobStatus.FAILED;
+        }
+        return false;
     }
 
     public void updateStatus(JobStatus nextStatus) {

--- a/backend/src/test/java/com/scalevision/backend/domain/model/ProcessingJobTest.java
+++ b/backend/src/test/java/com/scalevision/backend/domain/model/ProcessingJobTest.java
@@ -1,0 +1,94 @@
+package com.scalevision.backend.domain.model;
+
+import com.scalevision.backend.domain.exception.InvalidStatusTransitionException;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProcessingJobTest {
+
+    @Test
+    void shouldCreateJobWithPendingStatus() {
+        ProcessingJob job = buildJob();
+
+        assertNotNull(job.getId());
+        assertEquals("https://cdn.test/video.mp4", job.getVideoUrl());
+        assertEquals(JobStatus.PENDING, job.getStatus());
+        assertNotNull(job.getCreatedAt());
+        assertNotNull(job.getUpdatedAt());
+    }
+
+    @Test
+    void shouldAllowValidTransitionFromPendingToProcessing() {
+        ProcessingJob job = buildJob();
+
+        assertTrue(job.canTransitionTo(JobStatus.PROCESSING));
+        assertDoesNotThrow(() -> job.updateStatus(JobStatus.PROCESSING));
+        assertEquals(JobStatus.PROCESSING, job.getStatus());
+    }
+
+    @Test
+    void shouldAllowValidTransitionFromProcessingToCompleted() {
+        ProcessingJob job = buildJob();
+        job.updateStatus(JobStatus.PROCESSING);
+
+        assertTrue(job.canTransitionTo(JobStatus.COMPLETED));
+        job.updateStatus(JobStatus.COMPLETED);
+
+        assertEquals(JobStatus.COMPLETED, job.getStatus());
+    }
+
+    @Test
+    void shouldRejectInvalidTransitionFromPendingToCompleted() {
+        ProcessingJob job = buildJob();
+
+        assertFalse(job.canTransitionTo(JobStatus.COMPLETED));
+        assertThrows(
+                InvalidStatusTransitionException.class,
+                () -> job.updateStatus(JobStatus.COMPLETED)
+        );
+    }
+
+    @Test
+    void shouldKeepFinalStatusWithoutTransitions() {
+        ProcessingJob job = buildJob();
+        job.updateStatus(JobStatus.PROCESSING);
+        job.updateStatus(JobStatus.FAILED);
+
+        assertFalse(job.canTransitionTo(JobStatus.PROCESSING));
+        assertFalse(job.canTransitionTo(JobStatus.COMPLETED));
+        assertThrows(
+                InvalidStatusTransitionException.class,
+                () -> job.updateStatus(JobStatus.PROCESSING)
+        );
+    }
+
+    @Test
+    void shouldUpdateTimestampWhenStatusChanges() {
+        ProcessingJob job = buildJob();
+        LocalDateTime previousUpdatedAt = job.getUpdatedAt();
+
+        job.updateStatus(JobStatus.PROCESSING);
+
+        assertTrue(job.getUpdatedAt().isAfter(previousUpdatedAt)
+                || job.getUpdatedAt().isEqual(previousUpdatedAt));
+    }
+
+    private ProcessingJob buildJob() {
+        return new ProcessingJob(
+                UUID.randomUUID(),
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        );
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/domain/model/ProcessingJobTest.java
+++ b/backend/src/test/java/com/scalevision/backend/domain/model/ProcessingJobTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,7 +30,7 @@ class ProcessingJobTest {
         ProcessingJob job = buildJob();
 
         assertTrue(job.canTransitionTo(JobStatus.PROCESSING));
-        assertDoesNotThrow(() -> job.updateStatus(JobStatus.PROCESSING));
+        job.updateStatus(JobStatus.PROCESSING);
         assertEquals(JobStatus.PROCESSING, job.getStatus());
     }
 
@@ -80,6 +79,13 @@ class ProcessingJobTest {
 
         assertTrue(job.getUpdatedAt().isAfter(previousUpdatedAt)
                 || job.getUpdatedAt().isEqual(previousUpdatedAt));
+    }
+
+    @Test
+    void shouldNotAllowNullStatusTransition() {
+        ProcessingJob job = buildJob();
+
+        assertFalse(job.canTransitionTo(null));
     }
 
     private ProcessingJob buildJob() {


### PR DESCRIPTION
## Qué se hizo
Implementación de la Actividad 2 del backend (capa domain), con enfoque simple y legible.

### Archivos creados
- `backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java`
- `backend/src/main/java/com/scalevision/backend/domain/model/JobStatus.java`
- `backend/src/main/java/com/scalevision/backend/domain/exception/InvalidStatusTransitionException.java`
- `backend/src/test/java/com/scalevision/backend/domain/model/ProcessingJobTest.java`

## Reglas de negocio implementadas
- Estados: `PENDING`, `PROCESSING`, `COMPLETED`, `FAILED`
- Transiciones válidas:
  - `PENDING -> PROCESSING | FAILED`
  - `PROCESSING -> COMPLETED | FAILED`
  - `COMPLETED` y `FAILED` son estados finales

## Tests
Se agregaron pruebas unitarias para:
- creación de job en `PENDING`
- transiciones válidas
- transiciones inválidas
- estado final sin transición
- actualización de timestamp

Resultado local:
- `./mvnw test` ✅ (BUILD SUCCESS)

## Nota
Para siguientes tareas del MVP se usará Polling (no WebSocket).
