### PR TITLE
[BACKEND] Application - Definir Ports (Interfaces)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,9 @@ buildNumber.properties
 *.iws
 *.iml
 *.ipr
-out/
+/out/
+!backend/src/main/java/com/scalevision/backend/application/port/out/
+!backend/src/main/java/com/scalevision/backend/application/port/out/**
 
 ### VSCode ###
 .vscode/
@@ -85,5 +87,4 @@ coverage/
 ### Build Tool ###
 .gradle/
 build/
-
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -28,7 +28,9 @@ buildNumber.properties
 *.iws
 *.iml
 *.ipr
-out/
+/out/
+!src/main/java/com/scalevision/backend/application/port/out/
+!src/main/java/com/scalevision/backend/application/port/out/**
 
 ### VSCode ###
 .vscode/
@@ -85,5 +87,3 @@ coverage/
 ### Build Tool ###
 .gradle/
 build/
-
-

--- a/backend/src/main/java/com/scalevision/backend/application/port/in/GetJobStatusUseCase.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/in/GetJobStatusUseCase.java
@@ -1,0 +1,20 @@
+package com.scalevision.backend.application.port.in;
+
+import com.scalevision.backend.application.port.in.dto.JobStatusResult;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Retrieves the latest state of a processing job.
+ */
+public interface GetJobStatusUseCase {
+
+    /**
+     * Finds a job by id.
+     *
+     * @param jobId backend job id
+     * @return current job status if found
+     */
+    Optional<JobStatusResult> getJobStatus(UUID jobId);
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/in/ProcessVideoUseCase.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/in/ProcessVideoUseCase.java
@@ -1,0 +1,18 @@
+package com.scalevision.backend.application.port.in;
+
+import com.scalevision.backend.application.port.in.dto.ProcessVideoCommand;
+import com.scalevision.backend.application.port.in.dto.ProcessVideoResult;
+
+/**
+ * Starts the processing flow for a source video.
+ */
+public interface ProcessVideoUseCase {
+
+    /**
+     * Creates a new processing job and requests AI execution.
+     *
+     * @param command request data sent by the client
+     * @return created job information
+     */
+    ProcessVideoResult processVideo(ProcessVideoCommand command);
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/in/dto/JobStatusResult.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/in/dto/JobStatusResult.java
@@ -1,0 +1,16 @@
+package com.scalevision.backend.application.port.in.dto;
+
+import com.scalevision.backend.domain.model.JobStatus;
+
+import java.util.UUID;
+
+/**
+ * Current state of a processing job.
+ */
+public record JobStatusResult(
+        UUID jobId,
+        JobStatus status,
+        String outputUrl,
+        String errorMessage
+) {
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/in/dto/ProcessVideoCommand.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/in/dto/ProcessVideoCommand.java
@@ -1,0 +1,12 @@
+package com.scalevision.backend.application.port.in.dto;
+
+/**
+ * Data required to create a new video processing job.
+ */
+public record ProcessVideoCommand(
+        String videoUrl,
+        String targetAspectRatio,
+        Integer targetDuration,
+        String focusArea
+) {
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/in/dto/ProcessVideoResult.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/in/dto/ProcessVideoResult.java
@@ -1,0 +1,14 @@
+package com.scalevision.backend.application.port.in.dto;
+
+import com.scalevision.backend.domain.model.JobStatus;
+
+import java.util.UUID;
+
+/**
+ * Result returned after requesting a new job.
+ */
+public record ProcessVideoResult(
+        UUID jobId,
+        JobStatus status
+) {
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/out/AIServicePort.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/AIServicePort.java
@@ -1,0 +1,18 @@
+package com.scalevision.backend.application.port.out;
+
+import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
+import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
+
+/**
+ * Backend contract to communicate with AI service.
+ */
+public interface AIServicePort {
+
+    /**
+     * Sends a processing request to AI service.
+     *
+     * @param request processing payload
+     * @return AI acknowledgment data
+     */
+    AIProcessingResponse processVideo(AIProcessingRequest request);
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/out/JobRepository.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/JobRepository.java
@@ -1,0 +1,28 @@
+package com.scalevision.backend.application.port.out;
+
+import com.scalevision.backend.domain.model.ProcessingJob;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Persistence contract for processing jobs.
+ */
+public interface JobRepository {
+
+    /**
+     * Stores or updates a job.
+     *
+     * @param job domain job
+     * @return saved job
+     */
+    ProcessingJob save(ProcessingJob job);
+
+    /**
+     * Finds a job by backend id.
+     *
+     * @param id backend job id
+     * @return job if it exists
+     */
+    Optional<ProcessingJob> findById(UUID id);
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/out/NotificationPort.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/NotificationPort.java
@@ -1,0 +1,20 @@
+package com.scalevision.backend.application.port.out;
+
+import com.scalevision.backend.domain.model.JobStatus;
+
+import java.util.UUID;
+
+/**
+ * Notification contract for job updates.
+ */
+public interface NotificationPort {
+
+    /**
+     * Sends status updates to external clients.
+     *
+     * @param jobId backend job id
+     * @param status current job status
+     * @param message optional message
+     */
+    void notifyJobStatus(UUID jobId, JobStatus status, String message);
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingRequest.java
@@ -1,0 +1,13 @@
+package com.scalevision.backend.application.port.out.dto;
+
+/**
+ * Payload sent from backend to AI service.
+ */
+public record AIProcessingRequest(
+        String jobId,
+        String videoUrl,
+        String targetAspectRatio,
+        Integer targetDuration,
+        String focusArea
+) {
+}

--- a/backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingResponse.java
@@ -1,0 +1,10 @@
+package com.scalevision.backend.application.port.out.dto;
+
+/**
+ * Response returned by AI service after accepting a job.
+ */
+public record AIProcessingResponse(
+        String aiTaskId,
+        String status
+) {
+}


### PR DESCRIPTION
## Qué se hizo
Se implementó la Actividad 3 del backend: definición de puertos IN/OUT y DTOs mínimos para arquitectura hexagonal.

### Archivos creados
- `backend/src/main/java/com/scalevision/backend/application/port/in/ProcessVideoUseCase.java`
- `backend/src/main/java/com/scalevision/backend/application/port/in/GetJobStatusUseCase.java`
- `backend/src/main/java/com/scalevision/backend/application/port/in/dto/ProcessVideoCommand.java`
- `backend/src/main/java/com/scalevision/backend/application/port/in/dto/ProcessVideoResult.java`
- `backend/src/main/java/com/scalevision/backend/application/port/in/dto/JobStatusResult.java`
- `backend/src/main/java/com/scalevision/backend/application/port/out/AIServicePort.java`
- `backend/src/main/java/com/scalevision/backend/application/port/out/JobRepository.java`
- `backend/src/main/java/com/scalevision/backend/application/port/out/NotificationPort.java`
- `backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingRequest.java`
- `backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingResponse.java`

### Ajustes de repositorio
- `.gitignore` (raíz) y `backend/.gitignore` actualizados para evitar que la carpeta `application/port/out` sea ignorada por la regla `out/`.

## Validación
- Build/tests locales:
  - `./mvnw test` ✅ (`BUILD SUCCESS`)

## Notas
- No se implementa lógica de negocio en este PR, solo contratos de puertos.
- Se mantiene el enfoque del proyecto con Polling para tareas posteriores.
