### PR TITLE
[BACKEND] Application - Implementar ProcessVideoService

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/application/exception/VideoProcessingException.java
+++ b/backend/src/main/java/com/scalevision/backend/application/exception/VideoProcessingException.java
@@ -1,0 +1,12 @@
+package com.scalevision.backend.application.exception;
+
+public class VideoProcessingException extends RuntimeException {
+
+    public VideoProcessingException(String message) {
+        super(message);
+    }
+
+    public VideoProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/application/service/ProcessVideoService.java
+++ b/backend/src/main/java/com/scalevision/backend/application/service/ProcessVideoService.java
@@ -1,0 +1,81 @@
+package com.scalevision.backend.application.service;
+
+import com.scalevision.backend.application.exception.VideoProcessingException;
+import com.scalevision.backend.application.port.in.ProcessVideoUseCase;
+import com.scalevision.backend.application.port.in.dto.ProcessVideoCommand;
+import com.scalevision.backend.application.port.in.dto.ProcessVideoResult;
+import com.scalevision.backend.application.port.out.AIServicePort;
+import com.scalevision.backend.application.port.out.JobRepository;
+import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
+import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class ProcessVideoService implements ProcessVideoUseCase {
+
+    private final JobRepository jobRepository;
+    private final AIServicePort aiServicePort;
+
+    public ProcessVideoService(JobRepository jobRepository, AIServicePort aiServicePort) {
+        this.jobRepository = jobRepository;
+        this.aiServicePort = aiServicePort;
+    }
+
+    @Override
+    public ProcessVideoResult processVideo(ProcessVideoCommand command) {
+        validateCommand(command);
+
+        ProcessingJob job = new ProcessingJob(
+                UUID.randomUUID(),
+                command.videoUrl(),
+                command.targetAspectRatio(),
+                command.targetDuration(),
+                command.focusArea()
+        );
+
+        jobRepository.save(job);
+
+        try {
+            AIProcessingRequest request = new AIProcessingRequest(
+                    job.getId().toString(),
+                    job.getVideoUrl(),
+                    job.getTargetAspectRatio(),
+                    job.getTargetDuration(),
+                    job.getFocusArea()
+            );
+
+            AIProcessingResponse response = aiServicePort.processVideo(request);
+            job.setAiTaskId(response.aiTaskId());
+            job.updateStatus(JobStatus.PROCESSING);
+            jobRepository.save(job);
+
+            return new ProcessVideoResult(job.getId(), job.getStatus());
+        } catch (Exception ex) {
+            job.setErrorMessage(ex.getMessage());
+            if (job.canTransitionTo(JobStatus.FAILED)) {
+                job.updateStatus(JobStatus.FAILED);
+            }
+            jobRepository.save(job);
+            throw new VideoProcessingException("Error processing video", ex);
+        }
+    }
+
+    private void validateCommand(ProcessVideoCommand command) {
+        if (command == null) {
+            throw new VideoProcessingException("command is required");
+        }
+
+        String videoUrl = command.videoUrl();
+        if (videoUrl == null || videoUrl.isBlank()) {
+            throw new VideoProcessingException("videoUrl is required");
+        }
+
+        if (!videoUrl.startsWith("http://") && !videoUrl.startsWith("https://")) {
+            throw new VideoProcessingException("videoUrl is invalid");
+        }
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/ScalevisionBackendApplicationTests.java
+++ b/backend/src/test/java/com/scalevision/backend/ScalevisionBackendApplicationTests.java
@@ -1,10 +1,19 @@
 package com.scalevision.backend;
 
+import com.scalevision.backend.application.port.out.AIServicePort;
+import com.scalevision.backend.application.port.out.JobRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 class ScalevisionBackendApplicationTests {
+
+    @MockBean
+    private JobRepository jobRepository;
+
+    @MockBean
+    private AIServicePort aiServicePort;
 
     @Test
     void contextLoads() {

--- a/backend/src/test/java/com/scalevision/backend/application/service/ProcessVideoServiceTest.java
+++ b/backend/src/test/java/com/scalevision/backend/application/service/ProcessVideoServiceTest.java
@@ -1,0 +1,140 @@
+package com.scalevision.backend.application.service;
+
+import com.scalevision.backend.application.exception.VideoProcessingException;
+import com.scalevision.backend.application.port.in.dto.ProcessVideoCommand;
+import com.scalevision.backend.application.port.in.dto.ProcessVideoResult;
+import com.scalevision.backend.application.port.out.AIServicePort;
+import com.scalevision.backend.application.port.out.JobRepository;
+import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
+import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProcessVideoServiceTest {
+
+    @Test
+    void shouldCreateJobAndMoveToProcessingWhenAiAccepts() {
+        FakeJobRepository jobRepository = new FakeJobRepository();
+        FakeAIServicePort aiServicePort = new FakeAIServicePort(false);
+        ProcessVideoService service = new ProcessVideoService(jobRepository, aiServicePort);
+
+        ProcessVideoResult result = service.processVideo(validCommand());
+
+        assertNotNull(result.jobId());
+        assertEquals(JobStatus.PROCESSING, result.status());
+        assertEquals(2, jobRepository.savedJobs.size());
+        assertEquals(JobStatus.PENDING, jobRepository.savedJobs.get(0).getStatus());
+        assertEquals(JobStatus.PROCESSING, jobRepository.savedJobs.get(1).getStatus());
+        assertEquals("ai-task-001", jobRepository.savedJobs.get(1).getAiTaskId());
+    }
+
+    @Test
+    void shouldMarkJobAsFailedWhenAiThrowsError() {
+        FakeJobRepository jobRepository = new FakeJobRepository();
+        FakeAIServicePort aiServicePort = new FakeAIServicePort(true);
+        ProcessVideoService service = new ProcessVideoService(jobRepository, aiServicePort);
+
+        assertThrows(VideoProcessingException.class, () -> service.processVideo(validCommand()));
+        assertEquals(2, jobRepository.savedJobs.size());
+        assertEquals(JobStatus.FAILED, jobRepository.savedJobs.get(1).getStatus());
+        assertEquals("timeout from AI", jobRepository.savedJobs.get(1).getErrorMessage());
+    }
+
+    @Test
+    void shouldFailWhenVideoUrlIsInvalid() {
+        FakeJobRepository jobRepository = new FakeJobRepository();
+        FakeAIServicePort aiServicePort = new FakeAIServicePort(false);
+        ProcessVideoService service = new ProcessVideoService(jobRepository, aiServicePort);
+
+        ProcessVideoCommand command = new ProcessVideoCommand(
+                "ftp://video.mp4",
+                "9:16",
+                30,
+                "center"
+        );
+
+        assertThrows(VideoProcessingException.class, () -> service.processVideo(command));
+        assertEquals(0, jobRepository.savedJobs.size());
+    }
+
+    private ProcessVideoCommand validCommand() {
+        return new ProcessVideoCommand(
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        );
+    }
+
+    private static class FakeJobRepository implements JobRepository {
+
+        private final List<ProcessingJob> savedJobs = new ArrayList<>();
+
+        @Override
+        public ProcessingJob save(ProcessingJob job) {
+            savedJobs.add(cloneJob(job));
+            return job;
+        }
+
+        @Override
+        public Optional<ProcessingJob> findById(UUID id) {
+            return savedJobs.stream()
+                    .filter(job -> job.getId().equals(id))
+                    .findFirst();
+        }
+
+        private ProcessingJob cloneJob(ProcessingJob source) {
+            ProcessingJob copy = new ProcessingJob(
+                    source.getId(),
+                    source.getVideoUrl(),
+                    source.getTargetAspectRatio(),
+                    source.getTargetDuration(),
+                    source.getFocusArea()
+            );
+
+            if (source.getStatus() == JobStatus.PROCESSING) {
+                copy.updateStatus(JobStatus.PROCESSING);
+            }
+            if (source.getStatus() == JobStatus.FAILED) {
+                copy.updateStatus(JobStatus.FAILED);
+            }
+            if (source.getStatus() == JobStatus.COMPLETED) {
+                copy.updateStatus(JobStatus.PROCESSING);
+                copy.updateStatus(JobStatus.COMPLETED);
+            }
+
+            copy.setAiTaskId(source.getAiTaskId());
+            copy.setOutputUrl(source.getOutputUrl());
+            copy.setErrorMessage(source.getErrorMessage());
+
+            return copy;
+        }
+    }
+
+    private static class FakeAIServicePort implements AIServicePort {
+
+        private final boolean shouldThrow;
+
+        private FakeAIServicePort(boolean shouldThrow) {
+            this.shouldThrow = shouldThrow;
+        }
+
+        @Override
+        public AIProcessingResponse processVideo(AIProcessingRequest request) {
+            if (shouldThrow) {
+                throw new RuntimeException("timeout from AI");
+            }
+            return new AIProcessingResponse("ai-task-001", "accepted");
+        }
+    }
+}


### PR DESCRIPTION
## Qué se hizo
Se implementó la Actividad 4 del backend: `ProcessVideoService` para orquestar el flujo principal de procesamiento de video.

## Flujo implementado
1. Validar request (`videoUrl` requerido y formato `http/https`)
2. Crear `ProcessingJob` en estado `PENDING`
3. Guardar job en repositorio
4. Enviar request a IA (`AIServicePort`)
5. Actualizar job a `PROCESSING` y guardar `aiTaskId`
6. Si ocurre error, marcar job como `FAILED` y guardar `errorMessage`
7. Retornar `ProcessVideoResult`

### Archivos creados
- `backend/src/main/java/com/scalevision/backend/application/service/ProcessVideoService.java`
- `backend/src/main/java/com/scalevision/backend/application/exception/VideoProcessingException.java`
- `backend/src/test/java/com/scalevision/backend/application/service/ProcessVideoServiceTest.java`

### Archivo ajustado
- `backend/src/test/java/com/scalevision/backend/ScalevisionBackendApplicationTests.java`
  - se agregaron `@MockBean` para `JobRepository` y `AIServicePort` para permitir `contextLoads` sin adapters implementados aún.

## Tests
Se agregaron tests para:
- flujo exitoso (`PENDING -> PROCESSING`)
- error en IA (`FAILED`)
- URL inválida (`VideoProcessingException`)

Validación local:
- `./mvnw test` ✅ (`BUILD SUCCESS`)
