### PR TITLE
[BACKEND] Infrastructure - Crear JobEntity (JPA)

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java
+++ b/backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java
@@ -116,6 +116,28 @@ public class ProcessingJob {
         this.updatedAt = LocalDateTime.now();
     }
 
+    public void applyPersistenceState(
+            JobStatus persistedStatus,
+            String persistedAiTaskId,
+            String persistedOutputUrl,
+            String persistedErrorMessage
+    ) {
+        if (persistedStatus != null && persistedStatus != JobStatus.PENDING) {
+            if (persistedStatus == JobStatus.PROCESSING) {
+                this.updateStatus(JobStatus.PROCESSING);
+            } else if (persistedStatus == JobStatus.FAILED) {
+                this.updateStatus(JobStatus.FAILED);
+            } else if (persistedStatus == JobStatus.COMPLETED) {
+                this.updateStatus(JobStatus.PROCESSING);
+                this.updateStatus(JobStatus.COMPLETED);
+            }
+        }
+
+        this.aiTaskId = persistedAiTaskId;
+        this.outputUrl = persistedOutputUrl;
+        this.errorMessage = persistedErrorMessage;
+    }
+
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobEntity.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobEntity.java
@@ -1,0 +1,168 @@
+package com.scalevision.backend.infrastructure.adapter.out.persistence;
+
+import com.scalevision.backend.domain.model.JobStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "processing_job",
+        indexes = {
+                @Index(name = "idx_processing_job_status", columnList = "status"),
+                @Index(name = "idx_processing_job_created_at", columnList = "created_at")
+        }
+)
+public class JobEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "video_url", nullable = false, length = 1024)
+    private String videoUrl;
+
+    @Column(name = "target_aspect_ratio", length = 10)
+    private String targetAspectRatio;
+
+    @Column(name = "target_duration")
+    private Integer targetDuration;
+
+    @Column(name = "focus_area", length = 50)
+    private String focusArea;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private JobStatus status;
+
+    @Column(name = "ai_task_id", length = 255)
+    private String aiTaskId;
+
+    @Column(name = "output_url", length = 500)
+    private String outputUrl;
+
+    @Column(name = "error_message", length = 2000)
+    private String errorMessage;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    protected JobEntity() {
+    }
+
+    @PrePersist
+    public void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        if (updatedAt == null) {
+            updatedAt = now;
+        }
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getVideoUrl() {
+        return videoUrl;
+    }
+
+    public void setVideoUrl(String videoUrl) {
+        this.videoUrl = videoUrl;
+    }
+
+    public String getTargetAspectRatio() {
+        return targetAspectRatio;
+    }
+
+    public void setTargetAspectRatio(String targetAspectRatio) {
+        this.targetAspectRatio = targetAspectRatio;
+    }
+
+    public Integer getTargetDuration() {
+        return targetDuration;
+    }
+
+    public void setTargetDuration(Integer targetDuration) {
+        this.targetDuration = targetDuration;
+    }
+
+    public String getFocusArea() {
+        return focusArea;
+    }
+
+    public void setFocusArea(String focusArea) {
+        this.focusArea = focusArea;
+    }
+
+    public JobStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(JobStatus status) {
+        this.status = status;
+    }
+
+    public String getAiTaskId() {
+        return aiTaskId;
+    }
+
+    public void setAiTaskId(String aiTaskId) {
+        this.aiTaskId = aiTaskId;
+    }
+
+    public String getOutputUrl() {
+        return outputUrl;
+    }
+
+    public void setOutputUrl(String outputUrl) {
+        this.outputUrl = outputUrl;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobMapper.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobMapper.java
@@ -1,0 +1,43 @@
+package com.scalevision.backend.infrastructure.adapter.out.persistence;
+
+import com.scalevision.backend.domain.model.ProcessingJob;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobMapper {
+
+    public JobEntity toEntity(ProcessingJob job) {
+        JobEntity entity = new JobEntity();
+        entity.setId(job.getId());
+        entity.setVideoUrl(job.getVideoUrl());
+        entity.setTargetAspectRatio(job.getTargetAspectRatio());
+        entity.setTargetDuration(job.getTargetDuration());
+        entity.setFocusArea(job.getFocusArea());
+        entity.setStatus(job.getStatus());
+        entity.setAiTaskId(job.getAiTaskId());
+        entity.setOutputUrl(job.getOutputUrl());
+        entity.setErrorMessage(job.getErrorMessage());
+        entity.setCreatedAt(job.getCreatedAt());
+        entity.setUpdatedAt(job.getUpdatedAt());
+        return entity;
+    }
+
+    public ProcessingJob toDomain(JobEntity entity) {
+        ProcessingJob job = new ProcessingJob(
+                entity.getId(),
+                entity.getVideoUrl(),
+                entity.getTargetAspectRatio(),
+                entity.getTargetDuration(),
+                entity.getFocusArea()
+        );
+
+        job.applyPersistenceState(
+                entity.getStatus(),
+                entity.getAiTaskId(),
+                entity.getOutputUrl(),
+                entity.getErrorMessage()
+        );
+
+        return job;
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobMapperTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobMapperTest.java
@@ -1,0 +1,53 @@
+package com.scalevision.backend.infrastructure.adapter.out.persistence;
+
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JobMapperTest {
+
+    private final JobMapper mapper = new JobMapper();
+
+    @Test
+    void shouldMapDomainToEntity() {
+        ProcessingJob job = new ProcessingJob(
+                UUID.randomUUID(),
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        );
+        job.setAiTaskId("ai-task-1");
+        job.updateStatus(JobStatus.PROCESSING);
+
+        JobEntity entity = mapper.toEntity(job);
+
+        assertEquals(job.getId(), entity.getId());
+        assertEquals(job.getVideoUrl(), entity.getVideoUrl());
+        assertEquals(JobStatus.PROCESSING, entity.getStatus());
+        assertEquals("ai-task-1", entity.getAiTaskId());
+    }
+
+    @Test
+    void shouldMapEntityToDomain() {
+        JobEntity entity = new JobEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setVideoUrl("https://cdn.test/video.mp4");
+        entity.setTargetAspectRatio("9:16");
+        entity.setTargetDuration(30);
+        entity.setFocusArea("center");
+        entity.setStatus(JobStatus.FAILED);
+        entity.setErrorMessage("MODEL_TIMEOUT");
+
+        ProcessingJob job = mapper.toDomain(entity);
+
+        assertEquals(entity.getId(), job.getId());
+        assertEquals(entity.getVideoUrl(), job.getVideoUrl());
+        assertEquals(JobStatus.FAILED, job.getStatus());
+        assertEquals("MODEL_TIMEOUT", job.getErrorMessage());
+    }
+}


### PR DESCRIPTION
## Qué se hizo
Se implementó la Actividad 5 del backend: entidad JPA para jobs y mapper entre domain <-> persistence.

### Archivos creados
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobEntity.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobMapper.java`
- `backend/src/test/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobMapperTest.java`

### Archivo ajustado
- `backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java`
  - se agregó `applyPersistenceState(...)` para reconstruir el estado desde persistencia de forma simple.

## Implementación
- `JobEntity`:
  - mapeo de tabla `processing_job`
  - columnas principales (`id`, `video_url`, `status`, `ai_task_id`, `output_url`, `error_message`, `created_at`, `updated_at`)
  - `@PrePersist` y `@PreUpdate`
  - índices por `status` y `created_at`

- `JobMapper`:
  - `toEntity(ProcessingJob)` para persistir dominio
  - `toDomain(JobEntity)` para reconstruir dominio

## Tests
- tests de mapeo domain -> entity
- tests de mapeo entity -> domain
- validación local:
  - `./mvnw test` ✅ (`BUILD SUCCESS`)
