### PR TITLE
[BACKEND] Infrastructure - Crear VideoController

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest;
+
+import com.scalevision.backend.application.exception.VideoProcessingException;
+import com.scalevision.backend.infrastructure.adapter.in.rest.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        String message = "Invalid request";
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+        if (fieldError != null) {
+            message = fieldError.getDefaultMessage();
+        }
+
+        return ResponseEntity.badRequest().body(new ErrorResponse(
+                "BAD_REQUEST",
+                message,
+                LocalDateTime.now()
+        ));
+    }
+
+    @ExceptionHandler(VideoProcessingException.class)
+    public ResponseEntity<ErrorResponse> handleVideoProcessing(VideoProcessingException ex) {
+        return ResponseEntity.unprocessableEntity().body(new ErrorResponse(
+                "VIDEO_PROCESSING_ERROR",
+                ex.getMessage(),
+                LocalDateTime.now()
+        ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse(
+                "INTERNAL_ERROR",
+                "Unexpected server error",
+                LocalDateTime.now()
+        ));
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/VideoController.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/VideoController.java
@@ -1,0 +1,28 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest;
+
+import com.scalevision.backend.application.port.in.ProcessVideoUseCase;
+import com.scalevision.backend.application.port.in.dto.ProcessVideoResult;
+import com.scalevision.backend.infrastructure.adapter.in.rest.dto.ProcessVideoRequest;
+import com.scalevision.backend.infrastructure.adapter.in.rest.dto.ProcessVideoResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class VideoController {
+
+    private final ProcessVideoUseCase processVideoUseCase;
+
+    public VideoController(ProcessVideoUseCase processVideoUseCase) {
+        this.processVideoUseCase = processVideoUseCase;
+    }
+
+    @PostMapping("/videos/process")
+    public ResponseEntity<ProcessVideoResponse> processVideo(@Valid @RequestBody ProcessVideoRequest request) {
+        ProcessVideoResult result = processVideoUseCase.processVideo(request.toCommand());
+        ProcessVideoResponse response = new ProcessVideoResponse(result.jobId(), result.status().name());
+        return ResponseEntity.accepted().body(response);
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest.dto;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+        String code,
+        String message,
+        LocalDateTime timestamp
+) {
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoRequest.java
@@ -1,0 +1,18 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest.dto;
+
+import com.scalevision.backend.application.port.in.dto.ProcessVideoCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ProcessVideoRequest(
+        @NotBlank(message = "videoUrl is required")
+        @Pattern(regexp = "^https?://.*", message = "videoUrl must start with http:// or https://")
+        String videoUrl,
+        String targetAspectRatio,
+        Integer targetDuration,
+        String focusArea
+) {
+    public ProcessVideoCommand toCommand() {
+        return new ProcessVideoCommand(videoUrl, targetAspectRatio, targetDuration, focusArea);
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoResponse.java
@@ -1,0 +1,9 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest.dto;
+
+import java.util.UUID;
+
+public record ProcessVideoResponse(
+        UUID jobId,
+        String status
+) {
+}

--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/VideoControllerTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/VideoControllerTest.java
@@ -1,0 +1,89 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest;
+
+import com.scalevision.backend.application.exception.VideoProcessingException;
+import com.scalevision.backend.application.port.in.ProcessVideoUseCase;
+import com.scalevision.backend.application.port.in.dto.ProcessVideoResult;
+import com.scalevision.backend.domain.model.JobStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(VideoController.class)
+@Import(GlobalExceptionHandler.class)
+class VideoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProcessVideoUseCase processVideoUseCase;
+
+    @Test
+    void shouldReturn202WhenRequestIsValid() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        when(processVideoUseCase.processVideo(any()))
+                .thenReturn(new ProcessVideoResult(jobId, JobStatus.PROCESSING));
+
+        String requestJson = """
+                {
+                  "videoUrl": "https://cdn.test/video.mp4",
+                  "targetAspectRatio": "9:16",
+                  "targetDuration": 30,
+                  "focusArea": "center"
+                }
+                """;
+
+        mockMvc.perform(post("/videos/process")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.jobId").value(jobId.toString()))
+                .andExpect(jsonPath("$.status").value("PROCESSING"));
+    }
+
+    @Test
+    void shouldReturn400WhenRequestIsInvalid() throws Exception {
+        String requestJson = """
+                {
+                  "videoUrl": "",
+                  "targetAspectRatio": "9:16"
+                }
+                """;
+
+        mockMvc.perform(post("/videos/process")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void shouldReturn422WhenUseCaseThrowsVideoProcessingException() throws Exception {
+        when(processVideoUseCase.processVideo(any()))
+                .thenThrow(new VideoProcessingException("videoUrl is invalid"));
+
+        String requestJson = """
+                {
+                  "videoUrl": "https://cdn.test/video.mp4"
+                }
+                """;
+
+        mockMvc.perform(post("/videos/process")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("VIDEO_PROCESSING_ERROR"));
+    }
+}


### PR DESCRIPTION
## Qué se hizo
Se implementó la Actividad 6 del backend: endpoint REST para procesamiento de video y manejo global de errores.

### Archivos creados
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/VideoController.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoRequest.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoResponse.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ErrorResponse.java`
- `backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/VideoControllerTest.java`

## Endpoint implementado
- `POST /svmvp/videos/process`
- Request JSON validado con `@Valid`
- Response: `202 Accepted` con `jobId` y `status`

## Manejo de errores
- `400 Bad Request`: validación de request
- `422 Unprocessable Entity`: errores de procesamiento de video (`VideoProcessingException`)
- `500 Internal Server Error`: errores no controlados

## Tests
Se agregaron tests de controller para:
- caso exitoso (`202`)
- request inválido (`400`)
- excepción de use case (`422`)

Validación local:
- `./mvnw test` ✅ (`BUILD SUCCESS`)

## Nota
Implementación simple y legible, alineada al MVP.
