### PR TITLE
[BACKEND] Infrastructure - Crear CallbackController

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackController.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackController.java
@@ -1,0 +1,80 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest;
+
+import com.scalevision.backend.application.port.out.JobRepository;
+import com.scalevision.backend.domain.exception.InvalidStatusTransitionException;
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import com.scalevision.backend.infrastructure.adapter.in.rest.dto.AICallbackRequest;
+import com.scalevision.backend.infrastructure.adapter.in.rest.dto.CallbackResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@RestController
+public class CallbackController {
+
+    private final JobRepository jobRepository;
+
+    public CallbackController(JobRepository jobRepository) {
+        this.jobRepository = jobRepository;
+    }
+
+    @PostMapping("/callbacks/ai")
+    public ResponseEntity<CallbackResponse> handleAiCallback(@Valid @RequestBody AICallbackRequest request) {
+        UUID jobId = parseJobId(request.jobId());
+
+        ProcessingJob job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "job not found"));
+
+        JobStatus nextStatus = mapStatus(request.status());
+
+        try {
+            job.updateStatus(nextStatus);
+        } catch (InvalidStatusTransitionException ex) {
+            throw new ResponseStatusException(CONFLICT, ex.getMessage());
+        }
+
+        if (nextStatus == JobStatus.COMPLETED) {
+            job.setOutputUrl(request.outputUrl());
+        }
+
+        if (nextStatus == JobStatus.FAILED) {
+            job.setErrorMessage(request.errorMessage());
+        }
+
+        jobRepository.save(job);
+
+        return ResponseEntity.ok(new CallbackResponse(job.getId(), job.getStatus().name()));
+    }
+
+    private UUID parseJobId(String rawJobId) {
+        try {
+            return UUID.fromString(rawJobId);
+        } catch (Exception ex) {
+            throw new ResponseStatusException(BAD_REQUEST, "jobId is invalid");
+        }
+    }
+
+    private JobStatus mapStatus(String rawStatus) {
+        String normalized = rawStatus.trim().toUpperCase();
+
+        if ("COMPLETED".equals(normalized)) {
+            return JobStatus.COMPLETED;
+        }
+
+        if ("FAILED".equals(normalized)) {
+            return JobStatus.FAILED;
+        }
+
+        throw new ResponseStatusException(BAD_REQUEST, "status is invalid");
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 
@@ -34,6 +35,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity.unprocessableEntity().body(new ErrorResponse(
                 "VIDEO_PROCESSING_ERROR",
                 ex.getMessage(),
+                LocalDateTime.now()
+        ));
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatus(ResponseStatusException ex) {
+        String message = ex.getReason() != null ? ex.getReason() : ex.getStatusCode().toString();
+        return ResponseEntity.status(ex.getStatusCode()).body(new ErrorResponse(
+                "HTTP_" + ex.getStatusCode().value(),
+                message,
                 LocalDateTime.now()
         ));
     }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/AICallbackRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/AICallbackRequest.java
@@ -1,0 +1,20 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.validation.constraints.NotBlank;
+
+public record AICallbackRequest(
+        @NotBlank(message = "jobId is required")
+        @JsonAlias("job_id")
+        String jobId,
+
+        @NotBlank(message = "status is required")
+        String status,
+
+        @JsonAlias("output_url")
+        String outputUrl,
+
+        @JsonAlias("error_message")
+        String errorMessage
+) {
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/CallbackResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/CallbackResponse.java
@@ -1,0 +1,9 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest.dto;
+
+import java.util.UUID;
+
+public record CallbackResponse(
+        UUID jobId,
+        String status
+) {
+}

--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackControllerTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackControllerTest.java
@@ -1,0 +1,130 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest;
+
+import com.scalevision.backend.application.port.out.JobRepository;
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CallbackController.class)
+@Import(GlobalExceptionHandler.class)
+class CallbackControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JobRepository jobRepository;
+
+    @Test
+    void shouldUpdateJobToCompleted() throws Exception {
+        ProcessingJob job = processingJobInProgress();
+        when(jobRepository.findById(job.getId())).thenReturn(Optional.of(job));
+        when(jobRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        String request = """
+                {
+                  "job_id": "%s",
+                  "status": "completed",
+                  "output_url": "https://cdn.test/output.mp4"
+                }
+                """.formatted(job.getId());
+
+        mockMvc.perform(post("/callbacks/ai")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.jobId").value(job.getId().toString()))
+                .andExpect(jsonPath("$.status").value("COMPLETED"));
+    }
+
+    @Test
+    void shouldUpdateJobToFailed() throws Exception {
+        ProcessingJob job = processingJobInProgress();
+        when(jobRepository.findById(job.getId())).thenReturn(Optional.of(job));
+        when(jobRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        String request = """
+                {
+                  "job_id": "%s",
+                  "status": "failed",
+                  "error_message": "MODEL_TIMEOUT"
+                }
+                """.formatted(job.getId());
+
+        mockMvc.perform(post("/callbacks/ai")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("FAILED"));
+    }
+
+    @Test
+    void shouldReturn404WhenJobDoesNotExist() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        when(jobRepository.findById(jobId)).thenReturn(Optional.empty());
+
+        String request = """
+                {
+                  "job_id": "%s",
+                  "status": "completed"
+                }
+                """.formatted(jobId);
+
+        mockMvc.perform(post("/callbacks/ai")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn409WhenTransitionIsInvalid() throws Exception {
+        ProcessingJob job = new ProcessingJob(
+                UUID.randomUUID(),
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        );
+
+        when(jobRepository.findById(job.getId())).thenReturn(Optional.of(job));
+
+        String request = """
+                {
+                  "job_id": "%s",
+                  "status": "completed"
+                }
+                """.formatted(job.getId());
+
+        mockMvc.perform(post("/callbacks/ai")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isConflict());
+    }
+
+    private ProcessingJob processingJobInProgress() {
+        ProcessingJob job = new ProcessingJob(
+                UUID.randomUUID(),
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        );
+        job.updateStatus(JobStatus.PROCESSING);
+        return job;
+    }
+}


### PR DESCRIPTION
## Qué se hizo
Se implementó la Actividad 7 del backend: endpoint de callback para recibir resultados del servicio de IA.

### Archivos creados
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackController.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/AICallbackRequest.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/CallbackResponse.java`
- `backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackControllerTest.java`

### Archivo ajustado
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java`
  - se agregó manejo de `ResponseStatusException` para retornar HTTP status correctos (404, 409, etc).

## Endpoint implementado
- `POST /svmvp/callbacks/ai`
- Recibe callback IA y procesa estados `COMPLETED` o `FAILED`

## Flujo implementado
1. Recibir callback (`jobId`, `status`, `outputUrl/errorMessage`)
2. Buscar job por `jobId`
3. Validar y mapear estado
4. Aplicar transición de estado en dominio
5. Actualizar `outputUrl` o `errorMessage`
6. Guardar job actualizado
7. Retornar `200 OK`

## Casos de error cubiertos
- `400 Bad Request`: `jobId` inválido o `status` inválido
- `404 Not Found`: job no encontrado
- `409 Conflict`: transición de estado inválida

## Tests
Se agregaron tests para:
- callback `COMPLETED` -> job actualizado
- callback `FAILED` -> job fallido
- job no encontrado -> `404`
- transición inválida -> `409`

Validación local:
- `./mvnw test` ✅ (`BUILD SUCCESS`)

## Nota
Implementación intencionalmente simple, sin WebSocket (alineado al enfoque con Polling).
