### PR TITLE
[BACKEND] Infrastructure - Configurar Polling

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,7 +22,7 @@ como parte del MVP Prototype.
 -   Spring Web
 -   Spring Data JPA
 -   H2 Database (in-memory)
--   WebSocket
+-   Polling HTTP (consulta de estado de jobs)
 -   Lombok
 -   Bean Validation
 

--- a/backend/docs/ACTIVIDAD_8_POLLING.md
+++ b/backend/docs/ACTIVIDAD_8_POLLING.md
@@ -1,0 +1,106 @@
+# [BACKEND] Infrastructure - Configurar Polling
+
+## Estado
+Esta actividad reemplaza la actividad original:
+- `[BACKEND] Infrastructure - Configurar WebSocket`
+
+## Descripción
+Configurar Polling para que el frontend consulte el estado del job en intervalos regulares, en lugar de usar WebSocket.
+
+## Objetivos
+- Implementar endpoint de estado para polling en backend.
+- Exponer estado/progreso/resultado/error de un job.
+- Implementar servicio de consulta de estado (`GetJobStatusService`).
+- Integrar consulta de estado en el flujo actual (incluyendo callback IA).
+- Estandarizar respuestas HTTP para estados no encontrados y errores.
+- Escribir tests de endpoint y servicio.
+
+## Archivos a crear
+- `src/main/java/com/scalevision/backend/application/service/GetJobStatusService.java`
+- `src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusController.java`
+- `src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/JobStatusResponse.java`
+- `src/test/java/com/scalevision/backend/application/service/GetJobStatusServiceTest.java`
+- `src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusControllerTest.java`
+
+## Archivos a ajustar (si aplica)
+- `src/main/java/com/scalevision/backend/application/port/in/GetJobStatusUseCase.java`
+- `src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java`
+- `src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackController.java`
+
+## Configuración Polling (Frontend <-> Backend)
+- Endpoint polling: `GET /svmvp/jobs/{jobId}`
+- Intervalo sugerido frontend: cada 2-3 segundos
+- Timeout sugerido frontend: 120 segundos
+- Estados: `PENDING`, `PROCESSING`, `COMPLETED`, `FAILED`, `EXPIRED`
+
+## Contrato de respuesta (MVP)
+### 200 OK (processing)
+```json
+{
+  "jobId": "uuid",
+  "status": "PROCESSING",
+  "progressPercentage": 45,
+  "result": null,
+  "error": null
+}
+```
+
+### 200 OK (completed)
+```json
+{
+  "jobId": "uuid",
+  "status": "COMPLETED",
+  "progressPercentage": 100,
+  "result": {
+    "outputVideoUrl": "https://...",
+    "cropRecommendations": []
+  },
+  "error": null
+}
+```
+
+### 200 OK (failed)
+```json
+{
+  "jobId": "uuid",
+  "status": "FAILED",
+  "progressPercentage": 100,
+  "result": null,
+  "error": {
+    "code": "MODEL_TIMEOUT",
+    "message": "Tracking exceeded timeout.",
+    "retryable": true
+  }
+}
+```
+
+## Flujo
+1. Frontend inicia proceso (`POST /svmvp/videos/process`).
+2. Backend retorna `202 Accepted` + `jobId`.
+3. Frontend consulta `GET /svmvp/jobs/{jobId}` cada 2-3 segundos.
+4. Backend responde estado actual del job.
+5. IA envía callback y backend actualiza estado.
+6. Polling termina cuando `status = COMPLETED | FAILED | EXPIRED`.
+
+## Casos de error
+- `404 Not Found` -> Job no existe
+- `400 Bad Request` -> jobId inválido
+- `500 Internal Server Error` -> error inesperado
+
+## Tests
+- [ ] GET job existente en PROCESSING -> 200 + status correcto
+- [ ] GET job COMPLETED -> 200 + result con outputVideoUrl
+- [ ] GET job FAILED -> 200 + error con code/message
+- [ ] GET job inexistente -> 404
+- [ ] GET jobId inválido -> 400
+- [ ] Cobertura de mapeo domain -> response
+
+## Definición de Hecho
+- [ ] Polling implementado en endpoint `GET /svmvp/jobs/{jobId}`
+- [ ] `GetJobStatusService` implementado
+- [ ] DTO de respuesta definido y documentado
+- [ ] Tests unitarios y MockMvc pasando
+- [ ] Integración con flujo de callback validada
+- [ ] Sin dependencias WebSocket
+- [ ] Documentación actualizada
+- [ ] Code review aprobado

--- a/backend/src/main/java/com/scalevision/backend/application/service/GetJobStatusService.java
+++ b/backend/src/main/java/com/scalevision/backend/application/service/GetJobStatusService.java
@@ -1,0 +1,37 @@
+package com.scalevision.backend.application.service;
+
+import com.scalevision.backend.application.port.in.GetJobStatusUseCase;
+import com.scalevision.backend.application.port.in.dto.JobStatusResult;
+import com.scalevision.backend.application.port.out.JobRepository;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class GetJobStatusService implements GetJobStatusUseCase {
+
+    private final JobRepository jobRepository;
+
+    public GetJobStatusService(JobRepository jobRepository) {
+        this.jobRepository = jobRepository;
+    }
+
+    @Override
+    public Optional<JobStatusResult> getJobStatus(UUID jobId) {
+        Optional<ProcessingJob> jobOpt = jobRepository.findById(jobId);
+        if (jobOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ProcessingJob job = jobOpt.get();
+
+        return Optional.of(new JobStatusResult(
+                job.getId(),
+                job.getStatus(),
+                job.getOutputUrl(),
+                job.getErrorMessage()
+        ));
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.scalevision.backend.infrastructure.adapter.in.rest.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -26,6 +27,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(new ErrorResponse(
                 "BAD_REQUEST",
                 message,
+                LocalDateTime.now()
+        ));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(
+                "BAD_REQUEST",
+                "Invalid parameter type",
                 LocalDateTime.now()
         ));
     }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusController.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusController.java
@@ -1,0 +1,74 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest;
+
+import com.scalevision.backend.application.port.in.GetJobStatusUseCase;
+import com.scalevision.backend.application.port.in.dto.JobStatusResult;
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.infrastructure.adapter.in.rest.dto.JobStatusResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@RestController
+public class JobStatusController {
+
+    private final GetJobStatusUseCase getJobStatusUseCase;
+
+    public JobStatusController(GetJobStatusUseCase getJobStatusUseCase) {
+        this.getJobStatusUseCase = getJobStatusUseCase;
+    }
+
+    @GetMapping("/jobs/{jobId}")
+    public ResponseEntity<JobStatusResponse> getJobStatus(@PathVariable UUID jobId) {
+        JobStatusResult result = getJobStatusUseCase.getJobStatus(jobId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "job not found"));
+
+        Integer progressPercentage = resolveProgress(result.status());
+        JobStatusResponse.ResultData responseResult = null;
+        JobStatusResponse.ErrorData responseError = null;
+
+        if (result.status() == JobStatus.COMPLETED) {
+            responseResult = new JobStatusResponse.ResultData(result.outputUrl());
+        }
+
+        if (result.status() == JobStatus.FAILED) {
+            String errorCode = "PROCESSING_ERROR";
+            if (result.errorMessage() != null && result.errorMessage().matches("^[A-Z0-9_]+$")) {
+                errorCode = result.errorMessage();
+            }
+
+            responseError = new JobStatusResponse.ErrorData(
+                    errorCode,
+                    result.errorMessage(),
+                    false
+            );
+        }
+
+        JobStatusResponse response = new JobStatusResponse(
+                result.jobId(),
+                result.status().name(),
+                progressPercentage,
+                responseResult,
+                responseError
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    private Integer resolveProgress(JobStatus status) {
+        if (status == JobStatus.PENDING) {
+            return 0;
+        }
+
+        if (status == JobStatus.PROCESSING) {
+            return 50;
+        }
+
+        return 100;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/JobStatusResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/JobStatusResponse.java
@@ -1,0 +1,23 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest.dto;
+
+import java.util.UUID;
+
+public record JobStatusResponse(
+        UUID jobId,
+        String status,
+        Integer progressPercentage,
+        ResultData result,
+        ErrorData error
+) {
+    public record ResultData(
+            String outputVideoUrl
+    ) {
+    }
+
+    public record ErrorData(
+            String code,
+            String message,
+            Boolean retryable
+    ) {
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/application/service/GetJobStatusServiceTest.java
+++ b/backend/src/test/java/com/scalevision/backend/application/service/GetJobStatusServiceTest.java
@@ -1,0 +1,54 @@
+package com.scalevision.backend.application.service;
+
+import com.scalevision.backend.application.port.in.dto.JobStatusResult;
+import com.scalevision.backend.application.port.out.JobRepository;
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetJobStatusServiceTest {
+
+    @Test
+    void shouldReturnJobStatusWhenJobExists() {
+        JobRepository repository = mock(JobRepository.class);
+        GetJobStatusService service = new GetJobStatusService(repository);
+
+        ProcessingJob job = new ProcessingJob(
+                UUID.randomUUID(),
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        );
+        job.updateStatus(JobStatus.PROCESSING);
+
+        when(repository.findById(job.getId())).thenReturn(Optional.of(job));
+
+        Optional<JobStatusResult> result = service.getJobStatus(job.getId());
+
+        assertTrue(result.isPresent());
+        assertEquals(JobStatus.PROCESSING, result.get().status());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenJobDoesNotExist() {
+        JobRepository repository = mock(JobRepository.class);
+        GetJobStatusService service = new GetJobStatusService(repository);
+        UUID jobId = UUID.randomUUID();
+
+        when(repository.findById(jobId)).thenReturn(Optional.empty());
+
+        Optional<JobStatusResult> result = service.getJobStatus(jobId);
+
+        assertFalse(result.isPresent());
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusControllerTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusControllerTest.java
@@ -1,0 +1,91 @@
+package com.scalevision.backend.infrastructure.adapter.in.rest;
+
+import com.scalevision.backend.application.port.in.GetJobStatusUseCase;
+import com.scalevision.backend.application.port.in.dto.JobStatusResult;
+import com.scalevision.backend.domain.model.JobStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(JobStatusController.class)
+@Import(GlobalExceptionHandler.class)
+class JobStatusControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetJobStatusUseCase getJobStatusUseCase;
+
+    @Test
+    void shouldReturnProcessingStatus() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        when(getJobStatusUseCase.getJobStatus(jobId))
+                .thenReturn(Optional.of(new JobStatusResult(jobId, JobStatus.PROCESSING, null, null)));
+
+        mockMvc.perform(get("/jobs/{jobId}", jobId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PROCESSING"))
+                .andExpect(jsonPath("$.progressPercentage").value(50));
+    }
+
+    @Test
+    void shouldReturnCompletedStatusWithResult() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        when(getJobStatusUseCase.getJobStatus(jobId))
+                .thenReturn(Optional.of(new JobStatusResult(
+                        jobId,
+                        JobStatus.COMPLETED,
+                        "https://cdn.test/output.mp4",
+                        null
+                )));
+
+        mockMvc.perform(get("/jobs/{jobId}", jobId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.result.outputVideoUrl").value("https://cdn.test/output.mp4"));
+    }
+
+    @Test
+    void shouldReturnFailedStatusWithError() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        when(getJobStatusUseCase.getJobStatus(jobId))
+                .thenReturn(Optional.of(new JobStatusResult(
+                        jobId,
+                        JobStatus.FAILED,
+                        null,
+                        "MODEL_TIMEOUT"
+                )));
+
+        mockMvc.perform(get("/jobs/{jobId}", jobId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("FAILED"))
+                .andExpect(jsonPath("$.error.code").value("MODEL_TIMEOUT"));
+    }
+
+    @Test
+    void shouldReturn404WhenJobNotFound() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        when(getJobStatusUseCase.getJobStatus(jobId)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/jobs/{jobId}", jobId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn400WhenJobIdIsInvalid() throws Exception {
+        mockMvc.perform(get("/jobs/{jobId}", "abc"))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Qué se hizo
Se implementó la Actividad 8 reemplazada: configuración de Polling en lugar de WebSocket para consulta de estado de jobs.

## Implementación
### Capa Application
- Se creó `GetJobStatusService` para consultar estado de jobs desde repositorio.

### Capa Infrastructure (REST)
- Se creó endpoint de polling:
  - `GET /svmvp/jobs/{jobId}`
- Se creó DTO de respuesta:
  - `JobStatusResponse` con:
    - `jobId`
    - `status`
    - `progressPercentage`
    - `result`
    - `error`

### Manejo de errores HTTP
- `404` cuando el job no existe.
- `400` cuando `jobId` es inválido.
- Soporte agregado en `GlobalExceptionHandler` para `MethodArgumentTypeMismatchException`.

## Archivos creados
- `backend/src/main/java/com/scalevision/backend/application/service/GetJobStatusService.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusController.java`
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/JobStatusResponse.java`
- `backend/src/test/java/com/scalevision/backend/application/service/GetJobStatusServiceTest.java`
- `backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusControllerTest.java`
- `backend/docs/ACTIVIDAD_8_POLLING.md`

## Archivos ajustados
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/GlobalExceptionHandler.java`
- `backend/README.md` (tecnología actualizada a Polling)

## Tests
Se cubren escenarios:
- job existente en `PROCESSING` -> 200
- job `COMPLETED` -> 200 + `result.outputVideoUrl`
- job `FAILED` -> 200 + `error`
- job inexistente -> 404
- `jobId` inválido -> 400

Validación local:
- `./mvnw test` ✅ (`BUILD SUCCESS`)

## Nota
Implementación simple y legible, alineada al requerimiento del proyecto: Polling en vez de WebSocket.