### PR TITLE
[BACKEND] Testing - Tests Unitarios del Domain

### DIFF
--- a/backend/src/test/java/com/scalevision/backend/domain/model/JobStatusTest.java
+++ b/backend/src/test/java/com/scalevision/backend/domain/model/JobStatusTest.java
@@ -1,0 +1,27 @@
+package com.scalevision.backend.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JobStatusTest {
+
+    @Test
+    void shouldContainAllExpectedStatuses() {
+        JobStatus[] values = JobStatus.values();
+
+        assertEquals(4, values.length);
+        assertEquals(JobStatus.PENDING, values[0]);
+        assertEquals(JobStatus.PROCESSING, values[1]);
+        assertEquals(JobStatus.COMPLETED, values[2]);
+        assertEquals(JobStatus.FAILED, values[3]);
+    }
+
+    @Test
+    void shouldResolveStatusWithValueOf() {
+        assertEquals(JobStatus.PENDING, JobStatus.valueOf("PENDING"));
+        assertEquals(JobStatus.PROCESSING, JobStatus.valueOf("PROCESSING"));
+        assertEquals(JobStatus.COMPLETED, JobStatus.valueOf("COMPLETED"));
+        assertEquals(JobStatus.FAILED, JobStatus.valueOf("FAILED"));
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/domain/model/ProcessingJobTest.java
+++ b/backend/src/test/java/com/scalevision/backend/domain/model/ProcessingJobTest.java
@@ -46,6 +46,27 @@ class ProcessingJobTest {
     }
 
     @Test
+    void shouldAllowValidTransitionFromPendingToFailed() {
+        ProcessingJob job = buildJob();
+
+        assertTrue(job.canTransitionTo(JobStatus.FAILED));
+        job.updateStatus(JobStatus.FAILED);
+
+        assertEquals(JobStatus.FAILED, job.getStatus());
+    }
+
+    @Test
+    void shouldAllowValidTransitionFromProcessingToFailed() {
+        ProcessingJob job = buildJob();
+        job.updateStatus(JobStatus.PROCESSING);
+
+        assertTrue(job.canTransitionTo(JobStatus.FAILED));
+        job.updateStatus(JobStatus.FAILED);
+
+        assertEquals(JobStatus.FAILED, job.getStatus());
+    }
+
+    @Test
     void shouldRejectInvalidTransitionFromPendingToCompleted() {
         ProcessingJob job = buildJob();
 
@@ -58,6 +79,20 @@ class ProcessingJobTest {
 
     @Test
     void shouldKeepFinalStatusWithoutTransitions() {
+        ProcessingJob job = buildJob();
+        job.updateStatus(JobStatus.PROCESSING);
+        job.updateStatus(JobStatus.COMPLETED);
+
+        assertFalse(job.canTransitionTo(JobStatus.PROCESSING));
+        assertFalse(job.canTransitionTo(JobStatus.FAILED));
+        assertThrows(
+                InvalidStatusTransitionException.class,
+                () -> job.updateStatus(JobStatus.PROCESSING)
+        );
+    }
+
+    @Test
+    void shouldKeepFailedStatusWithoutTransitions() {
         ProcessingJob job = buildJob();
         job.updateStatus(JobStatus.PROCESSING);
         job.updateStatus(JobStatus.FAILED);


### PR DESCRIPTION
## Qué se hizo
Se completó la Actividad 9: pruebas unitarias de la capa Domain.

## Archivos modificados
- `backend/src/test/java/com/scalevision/backend/domain/model/ProcessingJobTest.java`
- `backend/src/test/java/com/scalevision/backend/domain/model/JobStatusTest.java`

## Cobertura de casos (Domain)
### ProcessingJobTest
- creación de job con valores correctos
- `PENDING -> PROCESSING`
- `PENDING -> FAILED`
- `PENDING` NO puede ir a `COMPLETED`
- `PROCESSING -> COMPLETED`
- `PROCESSING -> FAILED`
- `COMPLETED` NO puede cambiar
- `FAILED` NO puede cambiar
- `updateStatus` actualiza timestamp
- transición inválida lanza excepción

### JobStatusTest
- validación de estados existentes
- validación de `valueOf(...)`

## Validación
- Ejecución local:
  - `./mvnw test` ✅ (`BUILD SUCCESS`)

## Nota
Tests escritos con enfoque simple y legible, alineados a reglas de negocio del dominio.
