### PR TITLE
[BACKEND] Testing - Tests de Contrato con IA Service

### DIFF
--- a/backend/docs/AI_SERVICE_CONTRACT_TESTS.md
+++ b/backend/docs/AI_SERVICE_CONTRACT_TESTS.md
@@ -1,0 +1,25 @@
+# AI Service Contract Tests
+
+## Objetivo
+Validar el contrato HTTP entre Backend e IA para request de procesamiento y callback de resultados.
+
+## Cobertura
+### Request Backend -> IA (`POST /ai/process-video`)
+- request con todos los campos -> aceptado
+- request sin `job_id` -> error 400
+- request con `video_url` inválida -> error 422
+- timeout de IA -> error controlado
+
+### Callback IA -> Backend (`POST /svmvp/callbacks/ai`)
+- callback `COMPLETED` -> 200
+- callback `FAILED` -> 200
+- callback con `job_id` inexistente -> 404
+- callback con formato inválido -> 400
+
+## Herramientas
+- JUnit 5
+- WireMock
+- MockMvc (standalone)
+
+## Archivo de test
+- `src/test/java/com/scalevision/backend/integration/AIServiceContractTest.java`

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -70,6 +70,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
@@ -1,0 +1,86 @@
+package com.scalevision.backend.infrastructure.adapter.out.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scalevision.backend.application.exception.VideoProcessingException;
+import com.scalevision.backend.application.port.out.AIServicePort;
+import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
+import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class AIServiceHttpAdapter implements AIServicePort {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+    private final ObjectMapper objectMapper;
+
+    public AIServiceHttpAdapter(
+            @Value("${ai.service.base-url:http://localhost:8000/svmvp}") String baseUrl
+    ) {
+        this(baseUrl, 2000, 5000, new ObjectMapper());
+    }
+
+    public AIServiceHttpAdapter(String baseUrl, int connectTimeoutMs, int readTimeoutMs, ObjectMapper objectMapper) {
+        this.baseUrl = baseUrl;
+        this.objectMapper = objectMapper;
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(connectTimeoutMs);
+        requestFactory.setReadTimeout(readTimeoutMs);
+        this.restTemplate = new RestTemplate(requestFactory);
+    }
+
+    @Override
+    public AIProcessingResponse processVideo(AIProcessingRequest request) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("job_id", request.jobId());
+        payload.put("video_url", request.videoUrl());
+        payload.put("target_aspect_ratio", request.targetAspectRatio());
+        payload.put("target_duration", request.targetDuration());
+        payload.put("focus_area", request.focusArea());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(
+                    baseUrl + "/ai/process-video",
+                    new HttpEntity<>(payload, headers),
+                    String.class
+            );
+
+            JsonNode body = objectMapper.readTree(response.getBody());
+            String aiTaskId = readText(body, "ai_task_id", "job_id");
+            String status = readText(body, "status", "accepted");
+
+            return new AIProcessingResponse(aiTaskId, status);
+        } catch (HttpStatusCodeException ex) {
+            throw new VideoProcessingException("AI service error: HTTP " + ex.getStatusCode().value(), ex);
+        } catch (ResourceAccessException ex) {
+            throw new VideoProcessingException("AI service timeout", ex);
+        } catch (Exception ex) {
+            throw new VideoProcessingException("AI service unexpected error", ex);
+        }
+    }
+
+    private String readText(JsonNode node, String key, String fallback) {
+        JsonNode value = node.get(key);
+        if (value == null || value.isNull() || value.asText().isBlank()) {
+            return fallback;
+        }
+        return value.asText();
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/integration/AIServiceContractTest.java
+++ b/backend/src/test/java/com/scalevision/backend/integration/AIServiceContractTest.java
@@ -1,0 +1,251 @@
+package com.scalevision.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scalevision.backend.application.exception.VideoProcessingException;
+import com.scalevision.backend.application.port.out.JobRepository;
+import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
+import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import com.scalevision.backend.infrastructure.adapter.in.rest.CallbackController;
+import com.scalevision.backend.infrastructure.adapter.in.rest.GlobalExceptionHandler;
+import com.scalevision.backend.infrastructure.adapter.out.ai.AIServiceHttpAdapter;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AIServiceContractTest {
+
+    private MockWebServer mockWebServer;
+    private ObjectMapper objectMapper;
+    private AIServiceHttpAdapter adapter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        objectMapper = new ObjectMapper();
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        String baseUrl = mockWebServer.url("/svmvp").toString();
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+
+        adapter = new AIServiceHttpAdapter(baseUrl, 1000, 1000, objectMapper);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (mockWebServer != null) {
+            mockWebServer.shutdown();
+        }
+    }
+
+    @Test
+    void shouldSendRequestWithAllFieldsAndReceiveAccepted() throws Exception {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(202)
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"ai_task_id\":\"ai-001\",\"status\":\"accepted\"}"));
+
+        AIProcessingResponse response = adapter.processVideo(new AIProcessingRequest(
+                "job-001",
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        ));
+
+        assertEquals("ai-001", response.aiTaskId());
+        assertEquals("accepted", response.status());
+
+        RecordedRequest request = mockWebServer.takeRequest(2, TimeUnit.SECONDS);
+        assertEquals("/svmvp/ai/process-video", request.getPath());
+
+        JsonNode body = objectMapper.readTree(request.getBody().readUtf8());
+        assertEquals("job-001", body.get("job_id").asText());
+        assertEquals("https://cdn.test/video.mp4", body.get("video_url").asText());
+    }
+
+    @Test
+    void shouldHandle400WhenJobIdIsMissing() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(400));
+
+        assertThrows(VideoProcessingException.class, () -> adapter.processVideo(new AIProcessingRequest(
+                null,
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        )));
+    }
+
+    @Test
+    void shouldHandle422WhenVideoUrlIsInvalid() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(422));
+
+        assertThrows(VideoProcessingException.class, () -> adapter.processVideo(new AIProcessingRequest(
+                "job-001",
+                "invalid-url",
+                "9:16",
+                30,
+                "center"
+        )));
+    }
+
+    @Test
+    void shouldHandleTimeoutWhenIaTakesTooLong() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(202)
+                .setBody("{\"ai_task_id\":\"ai-001\",\"status\":\"accepted\"}")
+                .setBodyDelay(2, TimeUnit.SECONDS));
+
+        VideoProcessingException ex = assertThrows(VideoProcessingException.class, () -> adapter.processVideo(new AIProcessingRequest(
+                "job-001",
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        )));
+
+        assertTrue(ex.getMessage().contains("timeout") || ex.getMessage().contains("AI service"));
+    }
+
+    @Test
+    void shouldReturn200ForCompletedCallback() throws Exception {
+        InMemoryJobRepository repository = new InMemoryJobRepository();
+        ProcessingJob job = processingJobInProgress();
+        repository.save(job);
+
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(new CallbackController(repository))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        String callback = """
+                {
+                  "job_id": "%s",
+                  "status": "completed",
+                  "output_url": "https://cdn.test/output.mp4"
+                }
+                """.formatted(job.getId());
+
+        mockMvc.perform(post("/callbacks/ai")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callback))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldReturn200ForFailedCallback() throws Exception {
+        InMemoryJobRepository repository = new InMemoryJobRepository();
+        ProcessingJob job = processingJobInProgress();
+        repository.save(job);
+
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(new CallbackController(repository))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        String callback = """
+                {
+                  "job_id": "%s",
+                  "status": "failed",
+                  "error_message": "MODEL_TIMEOUT"
+                }
+                """.formatted(job.getId());
+
+        mockMvc.perform(post("/callbacks/ai")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callback))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldReturn404ForUnknownJobInCallback() throws Exception {
+        InMemoryJobRepository repository = new InMemoryJobRepository();
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(new CallbackController(repository))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        String callback = """
+                {
+                  "job_id": "%s",
+                  "status": "completed"
+                }
+                """.formatted(UUID.randomUUID());
+
+        mockMvc.perform(post("/callbacks/ai")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callback))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn400ForInvalidCallbackPayload() throws Exception {
+        InMemoryJobRepository repository = new InMemoryJobRepository();
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(new CallbackController(repository))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        String callback = """
+                {
+                  "job_id": "",
+                  "status": ""
+                }
+                """;
+
+        mockMvc.perform(post("/callbacks/ai")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(callback))
+                .andExpect(status().isBadRequest());
+    }
+
+    private ProcessingJob processingJobInProgress() {
+        ProcessingJob job = new ProcessingJob(
+                UUID.randomUUID(),
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center"
+        );
+        job.updateStatus(JobStatus.PROCESSING);
+        return job;
+    }
+
+    private static class InMemoryJobRepository implements JobRepository {
+        private final Map<UUID, ProcessingJob> storage = new HashMap<>();
+
+        @Override
+        public ProcessingJob save(ProcessingJob job) {
+            storage.put(job.getId(), job);
+            return job;
+        }
+
+        @Override
+        public Optional<ProcessingJob> findById(UUID id) {
+            return Optional.ofNullable(storage.get(id));
+        }
+    }
+}


### PR DESCRIPTION
## Qué se hizo
Se implementó la Actividad 10: tests de contrato entre Backend e IA para request de procesamiento y callback de resultados.

## Implementación
### Adaptador de integración IA
- Se creó `AIServiceHttpAdapter` para enviar `POST /ai/process-video` al servicio IA.
- Se mapearon campos del contrato JSON (`job_id`, `video_url`, etc).
- Se manejan errores HTTP y timeout con `VideoProcessingException`.

### Tests de contrato
- Se creó `AIServiceContractTest` en capa `integration`.
- Se usa `MockWebServer` para simular IA y validar request/response.
- Se valida callback IA -> Backend con `MockMvc` sobre `CallbackController`.

## Escenarios cubiertos
### Request Backend -> IA
- request con todos los campos -> aceptado
- request sin `jobId` -> error
- request con `videoUrl` inválida -> error
- timeout en llamada -> error controlado

### Callback IA -> Backend
- callback `COMPLETED` -> 200
- callback `FAILED` -> 200
- callback con `jobId` inexistente -> 404
- callback con payload inválido -> 400

## Archivos creados
- `backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java`
- `backend/src/test/java/com/scalevision/backend/integration/AIServiceContractTest.java`
- `backend/docs/AI_SERVICE_CONTRACT_TESTS.md`

## Archivo ajustado
- `backend/pom.xml`
  - se agregó dependencia de test: `mockwebserver`

## Validación
- `./mvnw test` ✅ (`BUILD SUCCESS`)

## Nota
Implementación simple y alineada al flujo actual con Polling.
