### PR TITLE
[BACKEND] Documentation (README + Architecture + Development + API)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,148 +1,102 @@
-# ScaleVision -- Backend
+# ScaleVision Backend (MVP)
 
-Backend oficial del proyecto **ScaleVision**.
+Backend del proyecto ScaleVision para procesar videos y generar shorts verticales.
 
-Este servicio será responsable de:
+## Objetivo del backend
 
--   Exponer la API principal del sistema
--   Orquestar el flujo de procesamiento de videos
--   Comunicarse con el servicio de IA
--   Gestionar estados y persistencia de datos
+- Exponer API REST para iniciar procesamiento de video.
+- Consultar estado del trabajo con polling HTTP.
+- Recibir callback de IA cuando termina o falla.
+- Mantener el modelo de dominio con arquitectura hexagonal.
 
-Actualmente este módulo contiene la **estructura base del proyecto**
-como parte del MVP Prototype.
+## Tecnologías
 
-------------------------------------------------------------------------
+- Java 21
+- Spring Boot 3.3.5
+- Maven Wrapper
+- Spring Web
+- Spring Data JPA
+- H2 (runtime)
+- Bean Validation
+- Lombok
 
-## 🚀 Tecnologías
+## Arquitectura
 
--   Java 21
--   Spring Boot
--   Maven
--   Spring Web
--   Spring Data JPA
--   H2 Database (in-memory)
--   Polling HTTP (consulta de estado de jobs)
--   Lombok
--   Bean Validation
+Se usa arquitectura hexagonal:
 
-------------------------------------------------------------------------
+- `domain`: entidades y reglas de negocio.
+- `application`: casos de uso y puertos.
+- `infrastructure`: controladores REST y adaptadores externos.
 
-## 📦 Estructura actual
+Más detalle en:
 
-En esta primera fase se configuró:
+- `docs/ARCHITECTURE.md`
 
--   Proyecto Maven con Spring Boot
--   Dependencias necesarias
--   Maven Wrapper
--   Configuración base para compilación
--   README con instrucciones de ejecución
+## API actual (MVP)
 
-No incluye aún:
+- `POST /videos/process`: crea un job de procesamiento.
+- `GET /jobs/{jobId}`: consulta estado por polling.
+- `POST /callbacks/ai`: callback del servicio IA.
 
--   Endpoints funcionales
--   Casos de uso
--   Lógica de dominio
--   Integración con IA
+Contrato completo y ejemplos en:
 
-------------------------------------------------------------------------
+- `docs/API.md`
 
-## 🛠 Requisitos
+## Flujo de polling
 
--   Java 21 instalado
--   Git
--   Permisos de ejecución en archivos (`chmod +x mvnw` si es necesario)
+1. Frontend llama `POST /videos/process`.
+2. Backend responde `202 Accepted` con `jobId`.
+3. Frontend consulta `GET /jobs/{jobId}` cada 2-5 segundos.
+4. Servicio IA llama `POST /callbacks/ai` con `COMPLETED` o `FAILED`.
+5. Frontend sigue consultando hasta estado final.
 
-------------------------------------------------------------------------
+## Puertos de trabajo
 
-## 🔧 Compilar el proyecto
+- Backend: `http://localhost:8080`
+- IA: `http://localhost:8000/svmvp` (base URL configurable)
+- Frontend: `http://localhost:3000`
 
-Desde la carpeta `backend` ejecutar:
+## Configuración mínima
 
-``` bash
-./mvnw clean install
-```
+Archivo actual:
 
-Si todo está correcto, deberías ver:
+- `src/main/resources/application.properties`
 
-BUILD SUCCESS
+Propiedad disponible:
 
-------------------------------------------------------------------------
+- `spring.application.name=scalevision-backend`
 
-## ▶ Ejecutar la aplicación
+Propiedad opcional para IA:
 
-``` bash
+- `ai.service.base-url=http://localhost:8000/svmvp`
+
+## Ejecución local
+
+Desde `/Users/tinus/Developer/scalevision/backend`:
+
+```bash
+./mvnw clean test
 ./mvnw spring-boot:run
 ```
 
-La aplicación iniciará en:
+## Desarrollo por actividades
 
-http://localhost:8080
+- Base principal backend: `scalevision-backend`
+- Ramas de trabajo: `feature/backend-activity-N-...`
+- Flujo recomendado: feature -> PR a `scalevision-backend` -> merge -> borrar feature
 
-------------------------------------------------------------------------
+Guía práctica de trabajo en ramas y PR:
 
-## 📂 Rama de trabajo
+- `docs/DEVELOPMENT.md`
 
-Este módulo vive en:
+## Estado actual del MVP
 
-scalevision-backend
+- Dominio base implementado (`ProcessingJob`, `JobStatus`).
+- Casos de uso de iniciar proceso y consultar estado.
+- Contrato inicial IA por HTTP validado con tests de contrato.
+- Polling implementado como estrategia oficial (sin WebSocket en MVP).
 
-Las nuevas funcionalidades deberán desarrollarse en ramas `feature/*` y
-luego abrir Pull Request hacia `scalevision-backend`.
+## Equipo Backend
 
-------------------------------------------------------------------------
-
-## 🎯 Estado del proyecto
-
-Fase actual:
-
-Configuración base del backend para el MVP.
-
-Siguientes pasos:
-
--   Definición de arquitectura hexagonal
--   Creación de casos de uso
--   Definición de contratos API
--   Integración con módulo de IA
-
-------------------------------------------------------------------------
-
-## 👥 Equipo Backend
-
-Proyecto desarrollado por personal cualificado en el área de Backend
-como parte una Simulación Laboral - Febrero 2026 de **NoCountry**, con enfoque en integración real entre disciplinas y buenas prácticas de desarrollo.
-
-**Integrantes**:
-
-⚙️ **Backend Team**
-
-<table>
-  <tr>
-    <!-- Backend 1 -->
-    <td align="center" width="200">
-      <a href="https://github.com/TinusLopez">
-        <img src="https://avatars.githubusercontent.com/u/73755236?v=4" width="120" style="border-radius:50%;" />
-        <br />
-        <strong>Florentino López</strong>
-      </a>
-      <br/>
-      <sub>Backend Lead</sub>
-    </td>
-    <!-- Backend 2 -->
-    <td align="center" width="200">
-      <a href="https://github.com/edwinmancilla">
-        <img src="https://avatars.githubusercontent.com/u/196448088?v=4" width="120" style="border-radius:50%;" />
-        <br />
-        <strong>Edwin Mancilla</strong>
-      </a>
-      <br />
-      <sub>Backend Developer</sub>
-    </td>
-  </tr>
-</table>
-
-------------------------------------------------------------------------
-
-ScaleVision\
-MVP enfocado en automatización inteligente de generación de shorts
-verticales a partir de video horizontal.
+- Backend Lead: [Florentino López](https://github.com/TinusLopez)
+- Backend Dev: [Edwin Mancilla](https://github.com/edwinmancilla)

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -1,0 +1,157 @@
+# API Backend MVP
+
+Base URL backend local:
+
+- `http://localhost:8080`
+
+## 1) Crear procesamiento
+
+Endpoint:
+
+- `POST /videos/process`
+
+Request:
+
+```json
+{
+  "videoUrl": "https://example.com/video.mp4",
+  "targetAspectRatio": "9:16",
+  "targetDuration": 30,
+  "focusArea": "speaker"
+}
+```
+
+Respuesta exitosa:
+
+- Status: `202 Accepted`
+
+```json
+{
+  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
+  "status": "PROCESSING"
+}
+```
+
+Errores comunes:
+
+- `400 Bad Request` si `videoUrl` es inválido o falta.
+
+## 2) Consultar estado (Polling)
+
+Endpoint:
+
+- `GET /jobs/{jobId}`
+
+Ejemplo:
+
+- `GET /jobs/b3b3f4cf-91be-46e4-a883-ef6d496f8f4a`
+
+Respuesta en proceso:
+
+- Status: `200 OK`
+
+```json
+{
+  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
+  "status": "PROCESSING",
+  "progressPercentage": 50,
+  "result": null,
+  "error": null
+}
+```
+
+Respuesta final exitosa:
+
+```json
+{
+  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
+  "status": "COMPLETED",
+  "progressPercentage": 100,
+  "result": {
+    "outputVideoUrl": "https://cdn.example.com/shorts/final.mp4"
+  },
+  "error": null
+}
+```
+
+Respuesta final con error:
+
+```json
+{
+  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
+  "status": "FAILED",
+  "progressPercentage": 100,
+  "result": null,
+  "error": {
+    "code": "PROCESSING_ERROR",
+    "message": "AI timeout",
+    "retryable": false
+  }
+}
+```
+
+Error por job inexistente:
+
+- `404 Not Found`
+
+## 3) Callback de IA
+
+Endpoint:
+
+- `POST /callbacks/ai`
+
+Request (éxito):
+
+```json
+{
+  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
+  "status": "COMPLETED",
+  "outputUrl": "https://cdn.example.com/shorts/final.mp4"
+}
+```
+
+Request (fallo):
+
+```json
+{
+  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
+  "status": "FAILED",
+  "errorMessage": "AI timeout"
+}
+```
+
+También soporta alias en snake_case:
+
+- `job_id`
+- `output_url`
+- `error_message`
+
+Respuesta:
+
+- Status: `200 OK`
+
+```json
+{
+  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
+  "status": "COMPLETED"
+}
+```
+
+## Polling recomendado para frontend
+
+- Frecuencia sugerida: cada `2` a `5` segundos.
+- Terminar polling cuando `status` sea `COMPLETED` o `FAILED`.
+
+## Integración con IA
+
+Base URL configurada en backend:
+
+- `ai.service.base-url` (default `http://localhost:8000/svmvp`)
+
+Endpoint consumido por backend:
+
+- `POST /ai/process-video`
+
+Ruta completa por default:
+
+- `http://localhost:8000/svmvp/ai/process-video`

--- a/backend/docs/ARCHITECTURE.md
+++ b/backend/docs/ARCHITECTURE.md
@@ -1,0 +1,96 @@
+# Arquitectura Backend (Hexagonal)
+
+## Vista general
+
+El backend usa arquitectura hexagonal para separar reglas de negocio de tecnología.
+
+Capas:
+
+- `domain`: modelo puro de negocio.
+- `application`: casos de uso + puertos.
+- `infrastructure`: REST, HTTP client, persistencia, config.
+
+## Estructura actual
+
+### 1. Domain
+
+Ubicación: `src/main/java/com/scalevision/backend/domain`
+
+- `model/ProcessingJob.java`
+- `model/JobStatus.java`
+- `exception/InvalidStatusTransitionException.java`
+
+Responsabilidad:
+
+- Reglas de transición de estado del job.
+- Datos principales del procesamiento.
+
+### 2. Application
+
+Ubicación: `src/main/java/com/scalevision/backend/application`
+
+Puertos de entrada (`port/in`):
+
+- `ProcessVideoUseCase`
+- `GetJobStatusUseCase`
+
+Puertos de salida (`port/out`):
+
+- `JobRepository`
+- `AIServicePort`
+- `NotificationPort` (reservado para evolución)
+
+Servicios:
+
+- `ProcessVideoService`
+- `GetJobStatusService`
+
+Responsabilidad:
+
+- Coordinar flujo entre dominio y adaptadores.
+
+### 3. Infrastructure
+
+Ubicación: `src/main/java/com/scalevision/backend/infrastructure`
+
+Adapters de entrada REST:
+
+- `VideoController`
+- `JobStatusController`
+- `CallbackController`
+- `GlobalExceptionHandler`
+
+Adapter de salida IA:
+
+- `AIServiceHttpAdapter`
+
+Persistencia (modelo inicial):
+
+- `JobEntity`
+- `JobMapper`
+
+## Flujo principal con polling
+
+1. `POST /videos/process` crea job con estado `PENDING`.
+2. Se llama al servicio IA y el job pasa a `PROCESSING`.
+3. Frontend consulta `GET /jobs/{jobId}` por polling.
+4. IA envía `POST /callbacks/ai` con `COMPLETED` o `FAILED`.
+5. El backend actualiza estado y el frontend ve el estado final en el siguiente poll.
+
+## Decisión técnica del MVP
+
+- Se usa polling HTTP para sincronizar estados con frontend.
+- No se usa WebSocket en esta versión MVP.
+
+## Diagrama simple
+
+```text
+Frontend --POST /videos/process--> Backend
+Frontend <--202 + jobId---------- Backend
+
+Frontend --GET /jobs/{jobId}----> Backend (polling)
+Frontend <--status/progress------ Backend
+
+Backend --POST /ai/process-video-> IA
+IA ------POST /callbacks/ai------> Backend
+```

--- a/backend/docs/DEVELOPMENT.md
+++ b/backend/docs/DEVELOPMENT.md
@@ -1,0 +1,89 @@
+# Guía de Desarrollo Backend
+
+## Requisitos
+
+- Java 21
+- Maven (o usar `./mvnw`)
+- Git
+- IntelliJ IDEA
+
+## Ejecutar en local
+
+Ruta:
+
+- `/Users/tinus/Developer/scalevision/backend`
+
+Comandos:
+
+```bash
+./mvnw clean test
+./mvnw spring-boot:run
+```
+
+## Estrategia de ramas
+
+Base de trabajo backend:
+
+- `scalevision-backend`
+
+Formato de rama por actividad:
+
+- `feature/backend-activity-<numero>-<nombre-corto>`
+
+Ejemplo:
+
+```bash
+git checkout scalevision-backend
+git pull origin scalevision-backend
+git checkout -b feature/backend-activity-11-documentation
+```
+
+## Flujo recomendado para cada actividad
+
+1. Crear rama `feature/*` desde `scalevision-backend`.
+2. Implementar solo la actividad asignada.
+3. Ejecutar tests.
+4. Commit con mensaje claro.
+5. Push de la rama.
+6. Crear PR: `base=scalevision-backend`, `compare=feature/...`.
+7. Merge PR.
+8. Borrar rama remota y local.
+
+## Comandos útiles de limpieza después de merge
+
+```bash
+git checkout scalevision-backend
+git pull origin scalevision-backend
+git branch -d feature/backend-activity-11-documentation
+git push origin --delete feature/backend-activity-11-documentation
+```
+
+Si el remoto ya no existe:
+
+```text
+error: remote ref does not exist
+```
+
+No es error crítico. Solo significa que ya fue eliminada.
+
+## PR de control a `dev` (cuando aplique)
+
+Si están trabajando por integración:
+
+- PR 1: `feature/*` -> `scalevision-backend`
+- PR 2: `scalevision-backend` -> `dev`
+
+Nota:
+
+- Si `dev` o `main` están protegidas y no permiten bypass a admin, siempre se necesita review para merge.
+
+## Convención para comentarios de control en PR
+
+Ejemplo:
+
+```text
+[BACKEND] Activity 11 completed
+- Docs: README, ARCHITECTURE, DEVELOPMENT, API
+- Polling documented as official MVP strategy
+- Ready for review
+```


### PR DESCRIPTION
## Descripción
Se completa la documentación del backend para el MVP usando polling (sin WebSocket).

## Cambios realizados
- Actualización de README con:
  - objetivo del backend
  - endpoints actuales
  - flujo de polling
  - puertos de integración backend/IA/frontend
  - estado actual del MVP
- Nuevo documento de arquitectura hexagonal:
  - `backend/docs/ARCHITECTURE.md`
- Nueva guía de desarrollo y flujo de ramas/PR:
  - `backend/docs/DEVELOPMENT.md`
- Nuevo contrato API REST con ejemplos JSON:
  - `backend/docs/API.md`

## Archivos
- `/Users/tinus/Developer/scalevision/backend/README.md`
- `/Users/tinus/Developer/scalevision/backend/docs/ARCHITECTURE.md`
- `/Users/tinus/Developer/scalevision/backend/docs/DEVELOPMENT.md`
- `/Users/tinus/Developer/scalevision/backend/docs/API.md`

## Nota de validación
No hay cambios de lógica de negocio ni código runtime; solo documentación.
