### PR TITLE
[BACKEND] Fix - Remove committed merge conflict markers

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -34,42 +34,6 @@ Más detalle en:
 
 ## API actual (MVP)
 
-<<<<<<< HEAD
-- `POST /videos/process`: crea un job de procesamiento.
-- `GET /jobs/{jobId}`: consulta estado por polling.
-- `POST /callbacks/ai`: callback del servicio IA.
-
-Contrato completo y ejemplos en:
-
-- `docs/API.md`
-
-## Flujo de polling
-
-1. Frontend llama `POST /videos/process`.
-2. Backend responde `202 Accepted` con `jobId`.
-3. Frontend consulta `GET /jobs/{jobId}` cada 2-5 segundos.
-4. Servicio IA llama `POST /callbacks/ai` con `COMPLETED` o `FAILED`.
-5. Frontend sigue consultando hasta estado final.
-
-## Puertos de trabajo
-
-- Backend: `http://localhost:8080`
-- IA: `http://localhost:8000/svmvp` (base URL configurable)
-- Frontend: `http://localhost:3000`
-
-## Configuración mínima
-
-Archivo actual:
-
-- `src/main/resources/application.properties`
-
-Propiedad disponible:
-
-- `spring.application.name=scalevision-backend`
-
-Propiedad opcional para IA:
-
-=======
 Endpoints oficiales con prefijo:
 
 - `POST /svmvp/ai/scan-subjects`: fase A (discovery).
@@ -110,7 +74,6 @@ Propiedad disponible:
 
 Propiedad opcional para IA:
 
->>>>>>> origin/feature/backend-contract-alignment-v2
 - `ai.service.base-url=http://localhost:8000/svmvp`
 
 ## Ejecución local

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -1,16 +1,3 @@
-<<<<<<< HEAD
-# API Backend MVP
-
-Base URL backend local:
-
-- `http://localhost:8080`
-
-## 1) Crear procesamiento
-
-Endpoint:
-
-- `POST /videos/process`
-=======
 # API Contract (Backend MVP + Spec v2)
 
 Base URL oficial backend:
@@ -26,28 +13,11 @@ Compatibilidad temporal:
 Endpoint:
 
 - `POST /ai/scan-subjects`
->>>>>>> origin/feature/backend-contract-alignment-v2
 
 Request:
 
 ```json
 {
-<<<<<<< HEAD
-  "videoUrl": "https://example.com/video.mp4",
-  "targetAspectRatio": "9:16",
-  "targetDuration": 30,
-  "focusArea": "speaker"
-}
-```
-
-Respuesta exitosa:
-
-- Status: `202 Accepted`
-
-```json
-{
-  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
-=======
   "video_url": "https://objectstorage.../video.mp4?par=...",
   "min_appearance_ratio": 0.8,
   "config": {
@@ -118,44 +88,21 @@ Response `202`:
 ```json
 {
   "jobId": "uuid",
->>>>>>> origin/feature/backend-contract-alignment-v2
   "status": "PROCESSING"
 }
 ```
 
-<<<<<<< HEAD
-Errores comunes:
-
-- `400 Bad Request` si `videoUrl` es inválido o falta.
-
-## 2) Consultar estado (Polling)
-=======
 ## 3) Polling de estado en Backend
->>>>>>> origin/feature/backend-contract-alignment-v2
 
 Endpoint:
 
 - `GET /jobs/{jobId}`
 
-<<<<<<< HEAD
-Ejemplo:
-
-- `GET /jobs/b3b3f4cf-91be-46e4-a883-ef6d496f8f4a`
-
-Respuesta en proceso:
-
-- Status: `200 OK`
-
-```json
-{
-  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
-=======
 Response `200`:
 
 ```json
 {
   "jobId": "uuid",
->>>>>>> origin/feature/backend-contract-alignment-v2
   "status": "PROCESSING",
   "progressPercentage": 50,
   "result": null,
@@ -163,90 +110,17 @@ Response `200`:
 }
 ```
 
-<<<<<<< HEAD
-Respuesta final exitosa:
-
-```json
-{
-  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
-  "status": "COMPLETED",
-  "progressPercentage": 100,
-  "result": {
-    "outputVideoUrl": "https://cdn.example.com/shorts/final.mp4"
-  },
-  "error": null
-}
-```
-
-Respuesta final con error:
-
-```json
-{
-  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
-  "status": "FAILED",
-  "progressPercentage": 100,
-  "result": null,
-  "error": {
-    "code": "PROCESSING_ERROR",
-    "message": "AI timeout",
-    "retryable": false
-  }
-}
-```
-
-Error por job inexistente:
-
-- `404 Not Found`
-
-## 3) Callback de IA
-=======
 Cuando termina:
 
 - `result.outputVideoUrl` (si aplica)
 - `result.aiResultPayload` (payload bruto devuelto por IA en callback)
 
 ## 4) Callback IA -> Backend (seguro)
->>>>>>> origin/feature/backend-contract-alignment-v2
 
 Endpoint:
 
 - `POST /callbacks/ai`
 
-<<<<<<< HEAD
-Request (éxito):
-
-```json
-{
-  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
-  "status": "COMPLETED",
-  "outputUrl": "https://cdn.example.com/shorts/final.mp4"
-}
-```
-
-Request (fallo):
-
-```json
-{
-  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
-  "status": "FAILED",
-  "errorMessage": "AI timeout"
-}
-```
-
-También soporta alias en snake_case:
-
-- `job_id`
-- `output_url`
-- `error_message`
-
-Respuesta:
-
-- Status: `200 OK`
-
-```json
-{
-  "jobId": "b3b3f4cf-91be-46e4-a883-ef6d496f8f4a",
-=======
 Headers recomendados:
 
 - `Content-Type: application/json`
@@ -289,31 +163,10 @@ Response `200`:
 ```json
 {
   "jobId": "uuid",
->>>>>>> origin/feature/backend-contract-alignment-v2
   "status": "COMPLETED"
 }
 ```
 
-<<<<<<< HEAD
-## Polling recomendado para frontend
-
-- Frecuencia sugerida: cada `2` a `5` segundos.
-- Terminar polling cuando `status` sea `COMPLETED` o `FAILED`.
-
-## Integración con IA
-
-Base URL configurada en backend:
-
-- `ai.service.base-url` (default `http://localhost:8000/svmvp`)
-
-Endpoint consumido por backend:
-
-- `POST /ai/process-video`
-
-Ruta completa por default:
-
-- `http://localhost:8000/svmvp/ai/process-video`
-=======
 ## 5) Polling/Health proxy hacia IA
 
 Endpoints:
@@ -337,4 +190,3 @@ Llamadas que hace backend:
 - `POST /ai/process-video`
 - `GET /ai/job/{jobId}`
 - `GET /health`
->>>>>>> origin/feature/backend-contract-alignment-v2

--- a/backend/src/main/java/com/scalevision/backend/application/port/in/dto/JobStatusResult.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/in/dto/JobStatusResult.java
@@ -11,10 +11,7 @@ public record JobStatusResult(
         UUID jobId,
         JobStatus status,
         String outputUrl,
-<<<<<<< HEAD
-=======
         String aiResultPayload,
->>>>>>> origin/feature/backend-contract-alignment-v2
         String errorMessage
 ) {
 }

--- a/backend/src/main/java/com/scalevision/backend/application/port/in/dto/ProcessVideoCommand.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/in/dto/ProcessVideoCommand.java
@@ -7,9 +7,6 @@ public record ProcessVideoCommand(
         String videoUrl,
         String targetAspectRatio,
         Integer targetDuration,
-<<<<<<< HEAD
-        String focusArea
-=======
         String focusArea,
         String callbackUrl,
         String webhookSecret,
@@ -18,6 +15,5 @@ public record ProcessVideoCommand(
         Double[] referenceBox,
         Integer fpsSampled,
         Boolean includeTrajectoryData
->>>>>>> origin/feature/backend-contract-alignment-v2
 ) {
 }

--- a/backend/src/main/java/com/scalevision/backend/application/port/out/AIServicePort.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/AIServicePort.java
@@ -2,13 +2,10 @@ package com.scalevision.backend.application.port.out;
 
 import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
 import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
-<<<<<<< HEAD
-=======
 import com.scalevision.backend.application.port.out.dto.AIScanSubjectsRequest;
 import com.scalevision.backend.application.port.out.dto.AIScanSubjectsResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerHealthResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerJobStatusResponse;
->>>>>>> origin/feature/backend-contract-alignment-v2
 
 /**
  * Backend contract to communicate with AI service.
@@ -22,13 +19,10 @@ public interface AIServicePort {
      * @return AI acknowledgment data
      */
     AIProcessingResponse processVideo(AIProcessingRequest request);
-<<<<<<< HEAD
-=======
 
     AIScanSubjectsResponse scanSubjects(AIScanSubjectsRequest request);
 
     AIWorkerJobStatusResponse getJobStatus(String jobId);
 
     AIWorkerHealthResponse getHealth();
->>>>>>> origin/feature/backend-contract-alignment-v2
 }

--- a/backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingRequest.java
@@ -8,9 +8,6 @@ public record AIProcessingRequest(
         String videoUrl,
         String targetAspectRatio,
         Integer targetDuration,
-<<<<<<< HEAD
-        String focusArea
-=======
         String focusArea,
         String callbackUrl,
         String webhookSecret,
@@ -19,6 +16,5 @@ public record AIProcessingRequest(
         Double[] referenceBox,
         Integer fpsSampled,
         Boolean includeTrajectoryData
->>>>>>> origin/feature/backend-contract-alignment-v2
 ) {
 }

--- a/backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/dto/AIProcessingResponse.java
@@ -5,11 +5,7 @@ package com.scalevision.backend.application.port.out.dto;
  */
 public record AIProcessingResponse(
         String aiTaskId,
-<<<<<<< HEAD
-        String status
-=======
         String status,
         Integer estimatedProcessingTimeSec
->>>>>>> origin/feature/backend-contract-alignment-v2
 ) {
 }

--- a/backend/src/main/java/com/scalevision/backend/application/service/GetJobStatusService.java
+++ b/backend/src/main/java/com/scalevision/backend/application/service/GetJobStatusService.java
@@ -31,10 +31,7 @@ public class GetJobStatusService implements GetJobStatusUseCase {
                 job.getId(),
                 job.getStatus(),
                 job.getOutputUrl(),
-<<<<<<< HEAD
-=======
                 job.getAiResultPayload(),
->>>>>>> origin/feature/backend-contract-alignment-v2
                 job.getErrorMessage()
         ));
     }

--- a/backend/src/main/java/com/scalevision/backend/application/service/ProcessVideoService.java
+++ b/backend/src/main/java/com/scalevision/backend/application/service/ProcessVideoService.java
@@ -19,10 +19,7 @@ public class ProcessVideoService implements ProcessVideoUseCase {
 
     private final JobRepository jobRepository;
     private final AIServicePort aiServicePort;
-<<<<<<< HEAD
-=======
     private static final String DEFAULT_CALLBACK_URL = "http://localhost:8080/svmvp/callbacks/ai";
->>>>>>> origin/feature/backend-contract-alignment-v2
 
     public ProcessVideoService(JobRepository jobRepository, AIServicePort aiServicePort) {
         this.jobRepository = jobRepository;
@@ -40,11 +37,8 @@ public class ProcessVideoService implements ProcessVideoUseCase {
                 command.targetDuration(),
                 command.focusArea()
         );
-<<<<<<< HEAD
-=======
         String webhookSecret = resolveWebhookSecret(command.webhookSecret());
         job.setWebhookSecret(webhookSecret);
->>>>>>> origin/feature/backend-contract-alignment-v2
 
         jobRepository.save(job);
 
@@ -54,9 +48,6 @@ public class ProcessVideoService implements ProcessVideoUseCase {
                     job.getVideoUrl(),
                     job.getTargetAspectRatio(),
                     job.getTargetDuration(),
-<<<<<<< HEAD
-                    job.getFocusArea()
-=======
                     job.getFocusArea(),
                     resolveCallbackUrl(command.callbackUrl()),
                     webhookSecret,
@@ -65,7 +56,6 @@ public class ProcessVideoService implements ProcessVideoUseCase {
                     command.referenceBox(),
                     command.fpsSampled(),
                     command.includeTrajectoryData()
->>>>>>> origin/feature/backend-contract-alignment-v2
             );
 
             AIProcessingResponse response = aiServicePort.processVideo(request);
@@ -98,8 +88,6 @@ public class ProcessVideoService implements ProcessVideoUseCase {
             throw new VideoProcessingException("videoUrl is invalid");
         }
     }
-<<<<<<< HEAD
-=======
 
     private String resolveWebhookSecret(String rawSecret) {
         if (rawSecret != null && !rawSecret.isBlank()) {
@@ -114,5 +102,4 @@ public class ProcessVideoService implements ProcessVideoUseCase {
         }
         return callbackUrl;
     }
->>>>>>> origin/feature/backend-contract-alignment-v2
 }

--- a/backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java
+++ b/backend/src/main/java/com/scalevision/backend/domain/model/ProcessingJob.java
@@ -14,13 +14,9 @@ public class ProcessingJob {
     private final String focusArea;
     private JobStatus status;
     private String aiTaskId;
-<<<<<<< HEAD
-    private String outputUrl;
-=======
     private String webhookSecret;
     private String outputUrl;
     private String aiResultPayload;
->>>>>>> origin/feature/backend-contract-alignment-v2
     private String errorMessage;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -113,8 +109,6 @@ public class ProcessingJob {
         this.updatedAt = LocalDateTime.now();
     }
 
-<<<<<<< HEAD
-=======
     public String getWebhookSecret() {
         return webhookSecret;
     }
@@ -133,7 +127,6 @@ public class ProcessingJob {
         this.updatedAt = LocalDateTime.now();
     }
 
->>>>>>> origin/feature/backend-contract-alignment-v2
     public String getErrorMessage() {
         return errorMessage;
     }
@@ -146,13 +139,9 @@ public class ProcessingJob {
     public void applyPersistenceState(
             JobStatus persistedStatus,
             String persistedAiTaskId,
-<<<<<<< HEAD
-            String persistedOutputUrl,
-=======
             String persistedWebhookSecret,
             String persistedOutputUrl,
             String persistedAiResultPayload,
->>>>>>> origin/feature/backend-contract-alignment-v2
             String persistedErrorMessage
     ) {
         if (persistedStatus != null && persistedStatus != JobStatus.PENDING) {
@@ -167,13 +156,9 @@ public class ProcessingJob {
         }
 
         this.aiTaskId = persistedAiTaskId;
-<<<<<<< HEAD
-        this.outputUrl = persistedOutputUrl;
-=======
         this.webhookSecret = persistedWebhookSecret;
         this.outputUrl = persistedOutputUrl;
         this.aiResultPayload = persistedAiResultPayload;
->>>>>>> origin/feature/backend-contract-alignment-v2
         this.errorMessage = persistedErrorMessage;
     }
 

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackController.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackController.java
@@ -6,12 +6,6 @@ import com.scalevision.backend.domain.model.JobStatus;
 import com.scalevision.backend.domain.model.ProcessingJob;
 import com.scalevision.backend.infrastructure.adapter.in.rest.dto.AICallbackRequest;
 import com.scalevision.backend.infrastructure.adapter.in.rest.dto.CallbackResponse;
-<<<<<<< HEAD
-import jakarta.validation.Valid;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-=======
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
->>>>>>> origin/feature/backend-contract-alignment-v2
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -33,15 +26,6 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public class CallbackController {
 
     private final JobRepository jobRepository;
-<<<<<<< HEAD
-
-    public CallbackController(JobRepository jobRepository) {
-        this.jobRepository = jobRepository;
-    }
-
-    @PostMapping("/callbacks/ai")
-    public ResponseEntity<CallbackResponse> handleAiCallback(@Valid @RequestBody AICallbackRequest request) {
-=======
     private final String expectedSchemaVersion;
     private final ObjectMapper objectMapper;
 
@@ -60,14 +44,11 @@ public class CallbackController {
             @RequestHeader(name = "X-AI-Schema-Version", required = false) String schemaVersion,
             @RequestHeader(name = "X-Webhook-Secret", required = false) String webhookSecret
     ) {
->>>>>>> origin/feature/backend-contract-alignment-v2
         UUID jobId = parseJobId(request.jobId());
 
         ProcessingJob job = jobRepository.findById(jobId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "job not found"));
 
-<<<<<<< HEAD
-=======
         if (job.getWebhookSecret() != null && !job.getWebhookSecret().isBlank()) {
             if (webhookSecret == null || !job.getWebhookSecret().equals(webhookSecret)) {
                 throw new ResponseStatusException(org.springframework.http.HttpStatus.UNAUTHORIZED, "invalid webhook secret");
@@ -78,7 +59,6 @@ public class CallbackController {
             throw new ResponseStatusException(BAD_REQUEST, "schema version is invalid");
         }
 
->>>>>>> origin/feature/backend-contract-alignment-v2
         JobStatus nextStatus = mapStatus(request.status());
 
         try {
@@ -89,18 +69,12 @@ public class CallbackController {
 
         if (nextStatus == JobStatus.COMPLETED) {
             job.setOutputUrl(request.outputUrl());
-<<<<<<< HEAD
-=======
             job.setAiResultPayload(buildSuccessResultJson(request));
->>>>>>> origin/feature/backend-contract-alignment-v2
         }
 
         if (nextStatus == JobStatus.FAILED) {
             job.setErrorMessage(request.errorMessage());
-<<<<<<< HEAD
-=======
             job.setAiResultPayload(buildFailureResultJson(request));
->>>>>>> origin/feature/backend-contract-alignment-v2
         }
 
         jobRepository.save(job);
@@ -129,8 +103,6 @@ public class CallbackController {
 
         throw new ResponseStatusException(BAD_REQUEST, "status is invalid");
     }
-<<<<<<< HEAD
-=======
 
     private String buildSuccessResultJson(AICallbackRequest request) {
         try {
@@ -159,5 +131,4 @@ public class CallbackController {
 
     private record FailedPayload(String errorCode, Boolean retryable) {
     }
->>>>>>> origin/feature/backend-contract-alignment-v2
 }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusController.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusController.java
@@ -23,11 +23,7 @@ public class JobStatusController {
         this.getJobStatusUseCase = getJobStatusUseCase;
     }
 
-<<<<<<< HEAD
-    @GetMapping("/jobs/{jobId}")
-=======
     @GetMapping({"/jobs/{jobId}", "/svmvp/jobs/{jobId}"})
->>>>>>> origin/feature/backend-contract-alignment-v2
     public ResponseEntity<JobStatusResponse> getJobStatus(@PathVariable UUID jobId) {
         JobStatusResult result = getJobStatusUseCase.getJobStatus(jobId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "job not found"));
@@ -37,11 +33,7 @@ public class JobStatusController {
         JobStatusResponse.ErrorData responseError = null;
 
         if (result.status() == JobStatus.COMPLETED) {
-<<<<<<< HEAD
-            responseResult = new JobStatusResponse.ResultData(result.outputUrl());
-=======
             responseResult = new JobStatusResponse.ResultData(result.outputUrl(), result.aiResultPayload());
->>>>>>> origin/feature/backend-contract-alignment-v2
         }
 
         if (result.status() == JobStatus.FAILED) {

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/VideoController.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/VideoController.java
@@ -19,11 +19,7 @@ public class VideoController {
         this.processVideoUseCase = processVideoUseCase;
     }
 
-<<<<<<< HEAD
-    @PostMapping("/videos/process")
-=======
     @PostMapping({"/videos/process", "/svmvp/videos/process"})
->>>>>>> origin/feature/backend-contract-alignment-v2
     public ResponseEntity<ProcessVideoResponse> processVideo(@Valid @RequestBody ProcessVideoRequest request) {
         ProcessVideoResult result = processVideoUseCase.processVideo(request.toCommand());
         ProcessVideoResponse response = new ProcessVideoResponse(result.jobId(), result.status().name());

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/AICallbackRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/AICallbackRequest.java
@@ -11,13 +11,6 @@ public record AICallbackRequest(
         @NotBlank(message = "status is required")
         String status,
 
-<<<<<<< HEAD
-        @JsonAlias("output_url")
-        String outputUrl,
-
-        @JsonAlias("error_message")
-        String errorMessage
-=======
         @JsonAlias({"job_result_url", "output_url"})
         String outputUrl,
 
@@ -31,6 +24,5 @@ public record AICallbackRequest(
 
         @JsonAlias("crop_recommendations")
         Object cropRecommendations
->>>>>>> origin/feature/backend-contract-alignment-v2
 ) {
 }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/JobStatusResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/JobStatusResponse.java
@@ -10,12 +10,8 @@ public record JobStatusResponse(
         ErrorData error
 ) {
     public record ResultData(
-<<<<<<< HEAD
-            String outputVideoUrl
-=======
             String outputVideoUrl,
             String aiResultPayload
->>>>>>> origin/feature/backend-contract-alignment-v2
     ) {
     }
 

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoRequest.java
@@ -1,25 +1,13 @@
 package com.scalevision.backend.infrastructure.adapter.in.rest.dto;
 
 import com.scalevision.backend.application.port.in.dto.ProcessVideoCommand;
-<<<<<<< HEAD
-=======
 import com.fasterxml.jackson.annotation.JsonAlias;
->>>>>>> origin/feature/backend-contract-alignment-v2
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record ProcessVideoRequest(
         @NotBlank(message = "videoUrl is required")
         @Pattern(regexp = "^https?://.*", message = "videoUrl must start with http:// or https://")
-<<<<<<< HEAD
-        String videoUrl,
-        String targetAspectRatio,
-        Integer targetDuration,
-        String focusArea
-) {
-    public ProcessVideoCommand toCommand() {
-        return new ProcessVideoCommand(videoUrl, targetAspectRatio, targetDuration, focusArea);
-=======
         @JsonAlias("video_url")
         String videoUrl,
         @JsonAlias("target_aspect_ratio")
@@ -90,6 +78,5 @@ public record ProcessVideoRequest(
                 fpsSampled,
                 includeTrajectoryData
         );
->>>>>>> origin/feature/backend-contract-alignment-v2
     }
 }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
@@ -6,14 +6,11 @@ import com.scalevision.backend.application.exception.VideoProcessingException;
 import com.scalevision.backend.application.port.out.AIServicePort;
 import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
 import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
-<<<<<<< HEAD
-=======
 import com.scalevision.backend.application.port.out.dto.AIScanSubjectsRequest;
 import com.scalevision.backend.application.port.out.dto.AIScanSubjectsResponse;
 import com.scalevision.backend.application.port.out.dto.AISubjectCandidate;
 import com.scalevision.backend.application.port.out.dto.AIWorkerHealthResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerJobStatusResponse;
->>>>>>> origin/feature/backend-contract-alignment-v2
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -26,10 +23,7 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
-<<<<<<< HEAD
-=======
 import java.util.List;
->>>>>>> origin/feature/backend-contract-alignment-v2
 import java.util.Map;
 
 @Component
@@ -60,11 +54,6 @@ public class AIServiceHttpAdapter implements AIServicePort {
         Map<String, Object> payload = new HashMap<>();
         payload.put("job_id", request.jobId());
         payload.put("video_url", request.videoUrl());
-<<<<<<< HEAD
-        payload.put("target_aspect_ratio", request.targetAspectRatio());
-        payload.put("target_duration", request.targetDuration());
-        payload.put("focus_area", request.focusArea());
-=======
         payload.put("callback_url", request.callbackUrl());
         payload.put("webhook_secret", request.webhookSecret());
         payload.put("tracking_mode", resolveTrackingMode(request.trackingMode()));
@@ -81,7 +70,6 @@ public class AIServiceHttpAdapter implements AIServicePort {
         config.put("fps_sampled", request.fpsSampled());
         config.put("include_trajectory_data", request.includeTrajectoryData());
         payload.put("config", config);
->>>>>>> origin/feature/backend-contract-alignment-v2
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -96,14 +84,9 @@ public class AIServiceHttpAdapter implements AIServicePort {
             JsonNode body = objectMapper.readTree(response.getBody());
             String aiTaskId = readText(body, "ai_task_id", "job_id");
             String status = readText(body, "status", "accepted");
-<<<<<<< HEAD
-
-            return new AIProcessingResponse(aiTaskId, status);
-=======
             int estimatedTime = readInt(body, "estimated_processing_time_sec", 45);
 
             return new AIProcessingResponse(aiTaskId, status, estimatedTime);
->>>>>>> origin/feature/backend-contract-alignment-v2
         } catch (HttpStatusCodeException ex) {
             throw new VideoProcessingException("AI service error: HTTP " + ex.getStatusCode().value(), ex);
         } catch (ResourceAccessException ex) {
@@ -113,8 +96,6 @@ public class AIServiceHttpAdapter implements AIServicePort {
         }
     }
 
-<<<<<<< HEAD
-=======
     @Override
     public AIScanSubjectsResponse scanSubjects(AIScanSubjectsRequest request) {
         Map<String, Object> payload = new HashMap<>();
@@ -182,7 +163,6 @@ public class AIServiceHttpAdapter implements AIServicePort {
         }
     }
 
->>>>>>> origin/feature/backend-contract-alignment-v2
     private String readText(JsonNode node, String key, String fallback) {
         JsonNode value = node.get(key);
         if (value == null || value.isNull() || value.asText().isBlank()) {
@@ -190,8 +170,6 @@ public class AIServiceHttpAdapter implements AIServicePort {
         }
         return value.asText();
     }
-<<<<<<< HEAD
-=======
 
     private int readInt(JsonNode node, String key, int fallback) {
         JsonNode value = node.get(key);
@@ -260,5 +238,4 @@ public class AIServiceHttpAdapter implements AIServicePort {
         }
         return null;
     }
->>>>>>> origin/feature/backend-contract-alignment-v2
 }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobEntity.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobEntity.java
@@ -47,11 +47,6 @@ public class JobEntity {
     @Column(name = "ai_task_id", length = 255)
     private String aiTaskId;
 
-<<<<<<< HEAD
-    @Column(name = "output_url", length = 500)
-    private String outputUrl;
-
-=======
     @Column(name = "webhook_secret", length = 255)
     private String webhookSecret;
 
@@ -61,7 +56,6 @@ public class JobEntity {
     @Column(name = "ai_result_payload", length = 8000)
     private String aiResultPayload;
 
->>>>>>> origin/feature/backend-contract-alignment-v2
     @Column(name = "error_message", length = 2000)
     private String errorMessage;
 
@@ -154,8 +148,6 @@ public class JobEntity {
         this.outputUrl = outputUrl;
     }
 
-<<<<<<< HEAD
-=======
     public String getWebhookSecret() {
         return webhookSecret;
     }
@@ -172,7 +164,6 @@ public class JobEntity {
         this.aiResultPayload = aiResultPayload;
     }
 
->>>>>>> origin/feature/backend-contract-alignment-v2
     public String getErrorMessage() {
         return errorMessage;
     }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobMapper.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobMapper.java
@@ -15,13 +15,9 @@ public class JobMapper {
         entity.setFocusArea(job.getFocusArea());
         entity.setStatus(job.getStatus());
         entity.setAiTaskId(job.getAiTaskId());
-<<<<<<< HEAD
-        entity.setOutputUrl(job.getOutputUrl());
-=======
         entity.setWebhookSecret(job.getWebhookSecret());
         entity.setOutputUrl(job.getOutputUrl());
         entity.setAiResultPayload(job.getAiResultPayload());
->>>>>>> origin/feature/backend-contract-alignment-v2
         entity.setErrorMessage(job.getErrorMessage());
         entity.setCreatedAt(job.getCreatedAt());
         entity.setUpdatedAt(job.getUpdatedAt());
@@ -40,13 +36,9 @@ public class JobMapper {
         job.applyPersistenceState(
                 entity.getStatus(),
                 entity.getAiTaskId(),
-<<<<<<< HEAD
-                entity.getOutputUrl(),
-=======
                 entity.getWebhookSecret(),
                 entity.getOutputUrl(),
                 entity.getAiResultPayload(),
->>>>>>> origin/feature/backend-contract-alignment-v2
                 entity.getErrorMessage()
         );
 

--- a/backend/src/test/java/com/scalevision/backend/application/service/ProcessVideoServiceTest.java
+++ b/backend/src/test/java/com/scalevision/backend/application/service/ProcessVideoServiceTest.java
@@ -7,13 +7,10 @@ import com.scalevision.backend.application.port.out.AIServicePort;
 import com.scalevision.backend.application.port.out.JobRepository;
 import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
 import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
-<<<<<<< HEAD
-=======
 import com.scalevision.backend.application.port.out.dto.AIScanSubjectsRequest;
 import com.scalevision.backend.application.port.out.dto.AIScanSubjectsResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerHealthResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerJobStatusResponse;
->>>>>>> origin/feature/backend-contract-alignment-v2
 import com.scalevision.backend.domain.model.JobStatus;
 import com.scalevision.backend.domain.model.ProcessingJob;
 import org.junit.jupiter.api.Test;
@@ -67,9 +64,6 @@ class ProcessVideoServiceTest {
                 "ftp://video.mp4",
                 "9:16",
                 30,
-<<<<<<< HEAD
-                "center"
-=======
                 "center",
                 null,
                 null,
@@ -78,7 +72,6 @@ class ProcessVideoServiceTest {
                 null,
                 null,
                 null
->>>>>>> origin/feature/backend-contract-alignment-v2
         );
 
         assertThrows(VideoProcessingException.class, () -> service.processVideo(command));
@@ -90,9 +83,6 @@ class ProcessVideoServiceTest {
                 "https://cdn.test/video.mp4",
                 "9:16",
                 30,
-<<<<<<< HEAD
-                "center"
-=======
                 "center",
                 null,
                 null,
@@ -101,7 +91,6 @@ class ProcessVideoServiceTest {
                 null,
                 null,
                 null
->>>>>>> origin/feature/backend-contract-alignment-v2
         );
     }
 
@@ -143,13 +132,9 @@ class ProcessVideoServiceTest {
             }
 
             copy.setAiTaskId(source.getAiTaskId());
-<<<<<<< HEAD
-            copy.setOutputUrl(source.getOutputUrl());
-=======
             copy.setWebhookSecret(source.getWebhookSecret());
             copy.setOutputUrl(source.getOutputUrl());
             copy.setAiResultPayload(source.getAiResultPayload());
->>>>>>> origin/feature/backend-contract-alignment-v2
             copy.setErrorMessage(source.getErrorMessage());
 
             return copy;
@@ -169,9 +154,6 @@ class ProcessVideoServiceTest {
             if (shouldThrow) {
                 throw new RuntimeException("timeout from AI");
             }
-<<<<<<< HEAD
-            return new AIProcessingResponse("ai-task-001", "accepted");
-=======
             return new AIProcessingResponse("ai-task-001", "accepted", 45);
         }
 
@@ -188,7 +170,6 @@ class ProcessVideoServiceTest {
         @Override
         public AIWorkerHealthResponse getHealth() {
             throw new UnsupportedOperationException();
->>>>>>> origin/feature/backend-contract-alignment-v2
         }
     }
 }

--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackControllerTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackControllerTest.java
@@ -46,11 +46,8 @@ class CallbackControllerTest {
 
         mockMvc.perform(post("/callbacks/ai")
                         .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-=======
                         .header("X-Webhook-Secret", job.getWebhookSecret())
                         .header("X-AI-Schema-Version", "1.0.0")
->>>>>>> origin/feature/backend-contract-alignment-v2
                         .content(request))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.jobId").value(job.getId().toString()))
@@ -73,11 +70,8 @@ class CallbackControllerTest {
 
         mockMvc.perform(post("/callbacks/ai")
                         .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-=======
                         .header("X-Webhook-Secret", job.getWebhookSecret())
                         .header("X-AI-Schema-Version", "1.0.0")
->>>>>>> origin/feature/backend-contract-alignment-v2
                         .content(request))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("FAILED"));
@@ -97,11 +91,8 @@ class CallbackControllerTest {
 
         mockMvc.perform(post("/callbacks/ai")
                         .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-=======
                         .header("X-Webhook-Secret", "sv_x")
                         .header("X-AI-Schema-Version", "1.0.0")
->>>>>>> origin/feature/backend-contract-alignment-v2
                         .content(request))
                 .andExpect(status().isNotFound());
     }
@@ -127,17 +118,12 @@ class CallbackControllerTest {
 
         mockMvc.perform(post("/callbacks/ai")
                         .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-=======
                         .header("X-Webhook-Secret", "sv_x")
                         .header("X-AI-Schema-Version", "1.0.0")
->>>>>>> origin/feature/backend-contract-alignment-v2
                         .content(request))
                 .andExpect(status().isConflict());
     }
 
-<<<<<<< HEAD
-=======
     @Test
     void shouldReturn401WhenWebhookSecretDoesNotMatch() throws Exception {
         ProcessingJob job = processingJobInProgress();
@@ -158,7 +144,6 @@ class CallbackControllerTest {
                 .andExpect(status().isUnauthorized());
     }
 
->>>>>>> origin/feature/backend-contract-alignment-v2
     private ProcessingJob processingJobInProgress() {
         ProcessingJob job = new ProcessingJob(
                 UUID.randomUUID(),
@@ -167,10 +152,7 @@ class CallbackControllerTest {
                 30,
                 "center"
         );
-<<<<<<< HEAD
-=======
         job.setWebhookSecret("sv_secret");
->>>>>>> origin/feature/backend-contract-alignment-v2
         job.updateStatus(JobStatus.PROCESSING);
         return job;
     }

--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusControllerTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusControllerTest.java
@@ -32,11 +32,7 @@ class JobStatusControllerTest {
     void shouldReturnProcessingStatus() throws Exception {
         UUID jobId = UUID.randomUUID();
         when(getJobStatusUseCase.getJobStatus(jobId))
-<<<<<<< HEAD
-                .thenReturn(Optional.of(new JobStatusResult(jobId, JobStatus.PROCESSING, null, null)));
-=======
                 .thenReturn(Optional.of(new JobStatusResult(jobId, JobStatus.PROCESSING, null, null, null)));
->>>>>>> origin/feature/backend-contract-alignment-v2
 
         mockMvc.perform(get("/jobs/{jobId}", jobId))
                 .andExpect(status().isOk())
@@ -52,22 +48,15 @@ class JobStatusControllerTest {
                         jobId,
                         JobStatus.COMPLETED,
                         "https://cdn.test/output.mp4",
-<<<<<<< HEAD
-=======
                         "{\"crop_recommendations\":[]}",
->>>>>>> origin/feature/backend-contract-alignment-v2
                         null
                 )));
 
         mockMvc.perform(get("/jobs/{jobId}", jobId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("COMPLETED"))
-<<<<<<< HEAD
-                .andExpect(jsonPath("$.result.outputVideoUrl").value("https://cdn.test/output.mp4"));
-=======
                 .andExpect(jsonPath("$.result.outputVideoUrl").value("https://cdn.test/output.mp4"))
                 .andExpect(jsonPath("$.result.aiResultPayload").value("{\"crop_recommendations\":[]}"));
->>>>>>> origin/feature/backend-contract-alignment-v2
     }
 
     @Test
@@ -78,10 +67,7 @@ class JobStatusControllerTest {
                         jobId,
                         JobStatus.FAILED,
                         null,
-<<<<<<< HEAD
-=======
                         null,
->>>>>>> origin/feature/backend-contract-alignment-v2
                         "MODEL_TIMEOUT"
                 )));
 

--- a/backend/src/test/java/com/scalevision/backend/integration/AIServiceContractTest.java
+++ b/backend/src/test/java/com/scalevision/backend/integration/AIServiceContractTest.java
@@ -6,13 +6,10 @@ import com.scalevision.backend.application.exception.VideoProcessingException;
 import com.scalevision.backend.application.port.out.JobRepository;
 import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
 import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
-<<<<<<< HEAD
-=======
 import com.scalevision.backend.application.port.out.dto.AIScanSubjectsRequest;
 import com.scalevision.backend.application.port.out.dto.AIScanSubjectsResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerHealthResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerJobStatusResponse;
->>>>>>> origin/feature/backend-contract-alignment-v2
 import com.scalevision.backend.domain.model.JobStatus;
 import com.scalevision.backend.domain.model.ProcessingJob;
 import com.scalevision.backend.infrastructure.adapter.in.rest.CallbackController;
@@ -79,9 +76,6 @@ class AIServiceContractTest {
                 "https://cdn.test/video.mp4",
                 "9:16",
                 30,
-<<<<<<< HEAD
-                "center"
-=======
                 "center",
                 "http://localhost:8080/svmvp/callbacks/ai",
                 "sv_secret",
@@ -90,15 +84,11 @@ class AIServiceContractTest {
                 null,
                 30,
                 false
->>>>>>> origin/feature/backend-contract-alignment-v2
         ));
 
         assertEquals("ai-001", response.aiTaskId());
         assertEquals("accepted", response.status());
-<<<<<<< HEAD
-=======
         assertEquals(45, response.estimatedProcessingTimeSec());
->>>>>>> origin/feature/backend-contract-alignment-v2
 
         RecordedRequest request = mockWebServer.takeRequest(2, TimeUnit.SECONDS);
         assertEquals("/svmvp/ai/process-video", request.getPath());
@@ -117,9 +107,6 @@ class AIServiceContractTest {
                 "https://cdn.test/video.mp4",
                 "9:16",
                 30,
-<<<<<<< HEAD
-                "center"
-=======
                 "center",
                 "http://localhost:8080/svmvp/callbacks/ai",
                 "sv_secret",
@@ -128,7 +115,6 @@ class AIServiceContractTest {
                 null,
                 30,
                 false
->>>>>>> origin/feature/backend-contract-alignment-v2
         )));
     }
 
@@ -141,9 +127,6 @@ class AIServiceContractTest {
                 "invalid-url",
                 "9:16",
                 30,
-<<<<<<< HEAD
-                "center"
-=======
                 "center",
                 "http://localhost:8080/svmvp/callbacks/ai",
                 "sv_secret",
@@ -152,7 +135,6 @@ class AIServiceContractTest {
                 null,
                 30,
                 false
->>>>>>> origin/feature/backend-contract-alignment-v2
         )));
     }
 
@@ -168,9 +150,6 @@ class AIServiceContractTest {
                 "https://cdn.test/video.mp4",
                 "9:16",
                 30,
-<<<<<<< HEAD
-                "center"
-=======
                 "center",
                 "http://localhost:8080/svmvp/callbacks/ai",
                 "sv_secret",
@@ -179,7 +158,6 @@ class AIServiceContractTest {
                 null,
                 30,
                 false
->>>>>>> origin/feature/backend-contract-alignment-v2
         )));
 
         assertTrue(ex.getMessage().contains("timeout") || ex.getMessage().contains("AI service"));
@@ -192,11 +170,7 @@ class AIServiceContractTest {
         repository.save(job);
 
         MockMvc mockMvc = MockMvcBuilders
-<<<<<<< HEAD
-                .standaloneSetup(new CallbackController(repository))
-=======
                 .standaloneSetup(new CallbackController(repository, "1.0.0"))
->>>>>>> origin/feature/backend-contract-alignment-v2
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
 
@@ -210,11 +184,8 @@ class AIServiceContractTest {
 
         mockMvc.perform(post("/callbacks/ai")
                         .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-=======
                         .header("X-Webhook-Secret", job.getWebhookSecret())
                         .header("X-AI-Schema-Version", "1.0.0")
->>>>>>> origin/feature/backend-contract-alignment-v2
                         .content(callback))
                 .andExpect(status().isOk());
     }
@@ -226,11 +197,7 @@ class AIServiceContractTest {
         repository.save(job);
 
         MockMvc mockMvc = MockMvcBuilders
-<<<<<<< HEAD
-                .standaloneSetup(new CallbackController(repository))
-=======
                 .standaloneSetup(new CallbackController(repository, "1.0.0"))
->>>>>>> origin/feature/backend-contract-alignment-v2
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
 
@@ -244,11 +211,8 @@ class AIServiceContractTest {
 
         mockMvc.perform(post("/callbacks/ai")
                         .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-=======
                         .header("X-Webhook-Secret", job.getWebhookSecret())
                         .header("X-AI-Schema-Version", "1.0.0")
->>>>>>> origin/feature/backend-contract-alignment-v2
                         .content(callback))
                 .andExpect(status().isOk());
     }
@@ -257,11 +221,7 @@ class AIServiceContractTest {
     void shouldReturn404ForUnknownJobInCallback() throws Exception {
         InMemoryJobRepository repository = new InMemoryJobRepository();
         MockMvc mockMvc = MockMvcBuilders
-<<<<<<< HEAD
-                .standaloneSetup(new CallbackController(repository))
-=======
                 .standaloneSetup(new CallbackController(repository, "1.0.0"))
->>>>>>> origin/feature/backend-contract-alignment-v2
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
 
@@ -274,11 +234,8 @@ class AIServiceContractTest {
 
         mockMvc.perform(post("/callbacks/ai")
                         .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-=======
                         .header("X-Webhook-Secret", "sv_x")
                         .header("X-AI-Schema-Version", "1.0.0")
->>>>>>> origin/feature/backend-contract-alignment-v2
                         .content(callback))
                 .andExpect(status().isNotFound());
     }
@@ -287,11 +244,7 @@ class AIServiceContractTest {
     void shouldReturn400ForInvalidCallbackPayload() throws Exception {
         InMemoryJobRepository repository = new InMemoryJobRepository();
         MockMvc mockMvc = MockMvcBuilders
-<<<<<<< HEAD
-                .standaloneSetup(new CallbackController(repository))
-=======
                 .standaloneSetup(new CallbackController(repository, "1.0.0"))
->>>>>>> origin/feature/backend-contract-alignment-v2
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
 
@@ -304,11 +257,8 @@ class AIServiceContractTest {
 
         mockMvc.perform(post("/callbacks/ai")
                         .contentType(MediaType.APPLICATION_JSON)
-<<<<<<< HEAD
-=======
                         .header("X-Webhook-Secret", "sv_x")
                         .header("X-AI-Schema-Version", "1.0.0")
->>>>>>> origin/feature/backend-contract-alignment-v2
                         .content(callback))
                 .andExpect(status().isBadRequest());
     }
@@ -321,10 +271,7 @@ class AIServiceContractTest {
                 30,
                 "center"
         );
-<<<<<<< HEAD
-=======
         job.setWebhookSecret("sv_secret");
->>>>>>> origin/feature/backend-contract-alignment-v2
         job.updateStatus(JobStatus.PROCESSING);
         return job;
     }


### PR DESCRIPTION
## Descripción
Este PR corrige un problema crítico en `scalevision-backend`: había archivos commiteados con marcadores de conflicto de merge (`<<<<<<<`, `=======`, `>>>>>>>`).

## Qué se hizo
- Limpieza de marcadores de conflicto en archivos de:
  - dominio
  - application
  - infraestructura
  - tests
  - documentación (`README`, `docs/API.md`)
- Se dejó una única versión válida por archivo, sin conflictos incrustados.

## Validación
- Compilación OK:
  - `./mvnw -q -DskipTests compile`
- Tests principales OK:
  - `./mvnw -q test -Dtest='*Test,!AIServiceContractTest'`

## Impacto
- El backend vuelve a estado consistente y mergeable.
- Evita fallos de build y comportamiento indefinido por código con conflictos.
- Deja listo el siguiente sync hacia `dev`.