### PR TITLE
[BACKEND] Fix - AIServiceHttpAdapter constructor wiring

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
@@ -11,6 +11,7 @@ import com.scalevision.backend.application.port.out.dto.AIScanSubjectsResponse;
 import com.scalevision.backend.application.port.out.dto.AISubjectCandidate;
 import com.scalevision.backend.application.port.out.dto.AIWorkerHealthResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerJobStatusResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -33,13 +34,14 @@ public class AIServiceHttpAdapter implements AIServicePort {
     private final String baseUrl;
     private final ObjectMapper objectMapper;
 
+    @Autowired
     public AIServiceHttpAdapter(
             @Value("${ai.service.base-url:http://localhost:8000/svmvp}") String baseUrl
     ) {
         this(baseUrl, 2000, 5000, new ObjectMapper());
     }
 
-    public AIServiceHttpAdapter(String baseUrl, int connectTimeoutMs, int readTimeoutMs, ObjectMapper objectMapper) {
+    AIServiceHttpAdapter(String baseUrl, int connectTimeoutMs, int readTimeoutMs, ObjectMapper objectMapper) {
         this.baseUrl = baseUrl;
         this.objectMapper = objectMapper;
 


### PR DESCRIPTION
## Descripción
Se corrige la creación del bean `AIServiceHttpAdapter` para evitar fallo al iniciar Spring Boot.

## Cambio
- Se marca el constructor principal con `@Autowired`.
- El constructor secundario (usado en tests) deja de ser público para evitar ambigüedad de inyección.

## Resultado
- El backend puede iniciar sin error de constructor del adapter IA.
