### PR TITLE
feat(config): setup application properties y perfiles dev/prod (#8)

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
@@ -41,7 +41,7 @@ public class AIServiceHttpAdapter implements AIServicePort {
         this(baseUrl, 2000, 5000, new ObjectMapper());
     }
 
-    AIServiceHttpAdapter(String baseUrl, int connectTimeoutMs, int readTimeoutMs, ObjectMapper objectMapper) {
+    public AIServiceHttpAdapter(String baseUrl, int connectTimeoutMs, int readTimeoutMs, ObjectMapper objectMapper) {
         this.baseUrl = baseUrl;
         this.objectMapper = objectMapper;
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,10 @@
+spring:
+  jpa:
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+
+logging:
+  level:
+    com.scalevision.backend: DEBUG

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+  h2:
+    console:
+      enabled: false
+
+ai:
+  service:
+    base-url: ${AI_SERVICE_URL}
+  callback:
+    schema-version: ${AI_CALLBACK_SCHEMA_VERSION}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,15 +1,22 @@
 spring.application.name=scalevision-backend
+# Server
+server.port=8080
 
 # H2 (desarrollo local)
 spring.datasource.url=jdbc:h2:mem:scalevisiondb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
+
+#JPA
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
+
+# H2 Console
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 
 # Integracion IA
-ai.service.base-url=http://localhost:8000/svmvp
-ai.callback.schema-version=1.0.0
+ai.service.base-url=${AI_SERVICE_URL:http://localhost:8000/svmvp}
+ai.callback.schema-version=${AI_CALLBACK_SCHEMA_VERSION:1.0.0}
+


### PR DESCRIPTION
 - Agrega server.port=8080 explícito

 - Usa variables de entorno con fallback para ai.service.base-url y ai.callback.schema-version

 - Crea application-dev.yml con show-sql=true y logs DEBUG para desarrollo

 - Crea application-prod.yml con variables de entorno sin fallback para forzar configuración en Docker
 
 ## Validación
- App inicia correctamente en puerto 8080
- H2 console accesible en http://localhost:8080/h2-console
- Tests compilan correctamente

<img width="1900" height="735" alt="image" src="https://github.com/user-attachments/assets/1c805407-26aa-47d6-ab5b-59bdbb189758" />


<img width="1912" height="960" alt="image" src="https://github.com/user-attachments/assets/41d80c53-9bc9-43b9-94dc-5c8c98252d6c" />


Closes #8