### PR TITLE
feat(domain): crear Value Object VideoMetadata con validaciones y tes…

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/domain/model/VideoMetadata.java
+++ b/backend/src/main/java/com/scalevision/backend/domain/model/VideoMetadata.java
@@ -1,0 +1,21 @@
+package com.scalevision.backend.domain.model;
+
+public record VideoMetadata(Integer duration,
+                            String resolution,
+                            String format,
+                            Long fileSize) {
+    public VideoMetadata{
+        if (duration == null || duration <= 0){
+            throw new IllegalArgumentException("La Duración debe ser mayor que 0");
+        }
+        if (resolution == null || !resolution.matches("\\d+x\\d+")){
+            throw new IllegalArgumentException("La Resolución debe estar en formato WxH (por ejemplo, 1920x1080)");
+        }
+        if (format == null || format.isBlank()){
+            throw new IllegalArgumentException("El Formato no puede ser nulo o vacío");
+        }
+        if (fileSize == null || fileSize <= 0){
+            throw new IllegalArgumentException("El Tamaño del Archivo debe ser mayor que 0");
+        }
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/domain/model/VideoMetadataTest.java
+++ b/backend/src/test/java/com/scalevision/backend/domain/model/VideoMetadataTest.java
@@ -1,0 +1,53 @@
+package com.scalevision.backend.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class VideoMetadataTest {
+    @Test
+    void deberiaCrearVideoMetadataValido() {
+        VideoMetadata metadata = new VideoMetadata(120, "1920x1080", "mp4", 1048576L);
+        assertEquals(120, metadata.duration());
+        assertEquals("1920x1080", metadata.resolution());
+        assertEquals("mp4", metadata.format());
+        assertEquals(1048576L, metadata.fileSize());
+    }
+
+    @Test
+    void deberiaFallarConDuracionCero() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new VideoMetadata(0, "1920x1080", "mp4", 1048576L));
+    }
+
+    @Test
+    void deberiaFallarConDuracionNegativa() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new VideoMetadata(-1, "1920x1080", "mp4", 1048576L));
+    }
+
+    @Test
+    void deberiaFallarConResolucionInvalida() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new VideoMetadata(120, "fullhd", "mp4", 1048576L));
+    }
+
+    @Test
+    void deberiaFallarConFormatoVacio() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new VideoMetadata(120, "1920x1080", "", 1048576L));
+    }
+
+    @Test
+    void deberiaFallarConFileSizeCero() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new VideoMetadata(120, "1920x1080", "mp4", 0L));
+    }
+
+    @Test
+    void deberiaFallarConFileSizeNegativa() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new VideoMetadata(120, "1920x1080", "mp4", -1L));
+    }
+}


### PR DESCRIPTION
…ts unitarios (#9)

- Crea VideoMetadata como record inmutable con campos duration, resolution, format y fileSize
- Implementa validaciones: duration > 0, resolution formato WxH, format no vacío, fileSize > 0
- Agrega 7 tests unitarios cubriendo caso válido y todas las validaciones de negocio


Closes #9 