### PR TITLE
feat(dtos): ajustar DTOs al contrato vigente (#10)

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackController.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/CallbackController.java
@@ -73,7 +73,7 @@ public class CallbackController {
         }
 
         if (nextStatus == JobStatus.FAILED) {
-            job.setErrorMessage(request.errorMessage());
+            job.setErrorMessage(request.errorCode());
             job.setAiResultPayload(buildFailureResultJson(request));
         }
 
@@ -118,7 +118,7 @@ public class CallbackController {
     private String buildFailureResultJson(AICallbackRequest request) {
         try {
             return objectMapper.writeValueAsString(new FailedPayload(
-                    request.errorMessage(),
+                    request.errorCode(),
                     request.retryable()
             ));
         } catch (Exception ex) {

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/AICallbackRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/AICallbackRequest.java
@@ -14,8 +14,8 @@ public record AICallbackRequest(
         @JsonAlias({"job_result_url", "output_url"})
         String outputUrl,
 
-        @JsonAlias({"error_code", "error_message"})
-        String errorMessage,
+        @JsonAlias({"error_code"})
+        String errorCode,
 
         Boolean retryable,
 

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/in/rest/dto/ProcessVideoRequest.java
@@ -16,6 +16,7 @@ public record ProcessVideoRequest(
         Integer targetDuration,
         @JsonAlias("focus_area")
         String focusArea,
+        @Pattern(regexp = "^https?://.*", message = "callbackUrl must start with http:// or https://")
         @JsonAlias("callback_url")
         String callbackUrl,
         @JsonAlias("webhook_secret")


### PR DESCRIPTION
- Reemplaza errorMessage con errorCode en AICallbackRequest segun contrato IA
- Actualiza CallbackController para usar errorCode() en lugar de errorMessage()
- Agrega validacion @Pattern en callbackUrl de ProcessVideoRequest

Closes #10