### PR TITLE
feat(repository): completar JobRepositoryAdapter con findAll, findByA…

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/application/port/out/JobRepository.java
+++ b/backend/src/main/java/com/scalevision/backend/application/port/out/JobRepository.java
@@ -1,7 +1,9 @@
 package com.scalevision.backend.application.port.out;
 
+import com.scalevision.backend.domain.model.JobStatus;
 import com.scalevision.backend.domain.model.ProcessingJob;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,4 +27,27 @@ public interface JobRepository {
      * @return job if it exists
      */
     Optional<ProcessingJob> findById(UUID id);
+
+    /**
+     * Retorna todos los jobs.
+     *
+     * @return lista de todos los jobs
+     */
+    List<ProcessingJob> findAll();
+
+    /**
+     * Busca un job por el id de tarea de la IA.
+     *
+     * @param aiTaskId id de tarea de la IA
+     * @return job si existe
+     */
+    Optional<ProcessingJob> findByAiTaskId(String aiTaskId);
+
+    /**
+     * Busca todos los jobs por estado.
+     *
+     * @param status estado del job
+     * @return lista de jobs con el estado dado
+     */
+    List<ProcessingJob> findByStatus(JobStatus status);
 }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JpaJobRepositoryAdapter.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JpaJobRepositoryAdapter.java
@@ -1,10 +1,12 @@
 package com.scalevision.backend.infrastructure.adapter.out.persistence;
 
 import com.scalevision.backend.application.port.out.JobRepository;
+import com.scalevision.backend.domain.model.JobStatus;
 import com.scalevision.backend.domain.model.ProcessingJob;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -29,5 +31,25 @@ public class JpaJobRepositoryAdapter implements JobRepository {
     @Override
     public Optional<ProcessingJob> findById(UUID id) {
         return jpaRepository.findById(id).map(jobMapper::toDomain);
+    }
+
+    @Override
+    public List<ProcessingJob> findAll() {
+        return jpaRepository.findAll().stream()
+                .map(jobMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<ProcessingJob> findByAiTaskId(String aiTaskId) {
+        return jpaRepository.findByAiTaskId(aiTaskId)
+                .map(jobMapper::toDomain);
+    }
+
+    @Override
+    public List<ProcessingJob> findByStatus(JobStatus status) {
+        return jpaRepository.findByStatus(status).stream()
+                .map(jobMapper::toDomain)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/SpringDataJobJpaRepository.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/persistence/SpringDataJobJpaRepository.java
@@ -1,8 +1,13 @@
 package com.scalevision.backend.infrastructure.adapter.out.persistence;
 
+import com.scalevision.backend.domain.model.JobStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface SpringDataJobJpaRepository extends JpaRepository<JobEntity, UUID> {
+    Optional<JobEntity>findByAiTaskId(String aiTaskId);
+    List<JobEntity>findByStatus(JobStatus status);
 }

--- a/backend/src/test/java/com/scalevision/backend/application/service/ProcessVideoServiceTest.java
+++ b/backend/src/test/java/com/scalevision/backend/application/service/ProcessVideoServiceTest.java
@@ -139,6 +139,25 @@ class ProcessVideoServiceTest {
 
             return copy;
         }
+
+        @Override
+        public List<ProcessingJob> findAll() {
+            return new ArrayList<>(savedJobs);
+        }
+
+        @Override
+        public Optional<ProcessingJob> findByAiTaskId(String aiTaskId) {
+            return savedJobs.stream()
+                    .filter(job -> aiTaskId.equals(job.getAiTaskId()))
+                    .findFirst();
+        }
+
+        @Override
+        public List<ProcessingJob> findByStatus(JobStatus status) {
+            return savedJobs.stream()
+                    .filter(job -> job.getStatus() == status)
+                    .toList();
+        }
     }
 
     private static class FakeAIServicePort implements AIServicePort {
@@ -172,4 +191,6 @@ class ProcessVideoServiceTest {
             throw new UnsupportedOperationException();
         }
     }
+
+
 }

--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/out/persistence/JobRepositoryAdapterTest.java
@@ -1,0 +1,68 @@
+package com.scalevision.backend.infrastructure.adapter.out.persistence;
+
+import com.scalevision.backend.domain.model.JobStatus;
+import com.scalevision.backend.domain.model.ProcessingJob;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaJobRepositoryAdapter.class, JobMapper.class})
+public class JobRepositoryAdapterTest {
+
+    @Autowired
+    private JpaJobRepositoryAdapter repository;
+
+    @Test
+    void deberiaSaveYFindById() {
+        ProcessingJob job = new ProcessingJob(UUID.randomUUID(), "https://video.com/test.mp4", "9:16", 30, "center");
+        repository.save(job);
+
+        Optional<ProcessingJob> found = repository.findById(job.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(job.getId());
+    }
+
+    @Test
+    void deberiaRetornarTodosLosJobs() {
+        repository.save(new ProcessingJob(UUID.randomUUID(), "https://video.com/1.mp4", "9:16", 30, "center"));
+        repository.save(new ProcessingJob(UUID.randomUUID(), "https://video.com/2.mp4", "9:16", 30, "center"));
+
+        List<ProcessingJob> all = repository.findAll();
+        assertThat(all).hasSizeGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void deberiaBuscarPorAiTaskId() {
+        ProcessingJob job = new ProcessingJob(UUID.randomUUID(), "https://video.com/test.mp4", "9:16", 30, "center");
+        job.setAiTaskId("ai-task-123");
+        repository.save(job);
+
+        Optional<ProcessingJob> found = repository.findByAiTaskId("ai-task-123");
+        assertThat(found).isPresent();
+        assertThat(found.get().getAiTaskId()).isEqualTo("ai-task-123");
+    }
+
+    @Test
+    void deberiaBuscarPorStatus() {
+        ProcessingJob job = new ProcessingJob(UUID.randomUUID(), "https://video.com/test.mp4", "9:16", 30, "center");
+        repository.save(job);
+
+        List<ProcessingJob> pending = repository.findByStatus(JobStatus.PENDING);
+        assertThat(pending).isNotEmpty();
+        assertThat(pending.get(0).getStatus()).isEqualTo(JobStatus.PENDING);
+    }
+
+    @Test
+    void deberiaRetornarVacioCuandoAiTaskIdNoExiste() {
+        Optional<ProcessingJob> found = repository.findByAiTaskId("no-existe");
+        assertThat(found).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/integration/AIServiceContractTest.java
+++ b/backend/src/test/java/com/scalevision/backend/integration/AIServiceContractTest.java
@@ -25,10 +25,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -288,6 +285,25 @@ class AIServiceContractTest {
         @Override
         public Optional<ProcessingJob> findById(UUID id) {
             return Optional.ofNullable(storage.get(id));
+        }
+
+        @Override
+        public List<ProcessingJob> findAll() {
+            return new ArrayList<>(storage.values());
+        }
+
+        @Override
+        public Optional<ProcessingJob> findByAiTaskId(String aiTaskId) {
+            return storage.values().stream()
+                    .filter(job -> aiTaskId.equals(job.getAiTaskId()))
+                    .findFirst();
+        }
+
+        @Override
+        public List<ProcessingJob> findByStatus(JobStatus status) {
+            return storage.values().stream()
+                    .filter(job -> job.getStatus() == status)
+                    .toList();
         }
     }
 }


### PR DESCRIPTION
…iTaskId y findByStatus (#12)

- Agrega findAll(), findByAiTaskId() y findByStatus() a JobRepository puerto
- Implementa los nuevos metodos en JpaJobRepositoryAdapter
- Agrega queries findByAiTaskId y findByStatus a SpringDataJobJpaRepository
- Crea tests de integracion con H2 en JobRepositoryAdapterTest (5 tests)

Closes #12