### PR TITLE
feat(controller): consolidar JobStatusController con test para ruta s…

### DIFF
--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusControllerTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/in/rest/JobStatusControllerTest.java
@@ -91,4 +91,15 @@ class JobStatusControllerTest {
         mockMvc.perform(get("/jobs/{jobId}", "abc"))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void shouldReturnProcessingStatusOnSvmvpPath() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        when(getJobStatusUseCase.getJobStatus(jobId))
+                .thenReturn(Optional.of(new JobStatusResult(jobId, JobStatus.PROCESSING, null, null, null)));
+
+        mockMvc.perform(get("/svmvp/jobs/{jobId}", jobId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PROCESSING"));
+    }
 }


### PR DESCRIPTION
…vmvp (#13)

- Agrega test shouldReturnProcessingStatusOnSvmvpPath para validar /svmvp/jobs/{jobId}
- Endpoint ya tenia 200, 400, 404 y estructura JSON completa para FE

Closes #13