### PR TITLE
feat(adapter): hardening AIServiceHttpAdapter con retry para 5xx (#14)

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapter.java
@@ -11,6 +11,8 @@ import com.scalevision.backend.application.port.out.dto.AIScanSubjectsResponse;
 import com.scalevision.backend.application.port.out.dto.AISubjectCandidate;
 import com.scalevision.backend.application.port.out.dto.AIWorkerHealthResponse;
 import com.scalevision.backend.application.port.out.dto.AIWorkerJobStatusResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -29,6 +31,9 @@ import java.util.Map;
 
 @Component
 public class AIServiceHttpAdapter implements AIServicePort {
+
+    private static final Logger log = LoggerFactory.getLogger(AIServiceHttpAdapter.class);
+    private static final int MAX_RETRIES = 2;
 
     private final RestTemplate restTemplate;
     private final String baseUrl;
@@ -49,10 +54,13 @@ public class AIServiceHttpAdapter implements AIServicePort {
         requestFactory.setConnectTimeout(connectTimeoutMs);
         requestFactory.setReadTimeout(readTimeoutMs);
         this.restTemplate = new RestTemplate(requestFactory);
+
+
     }
 
     @Override
     public AIProcessingResponse processVideo(AIProcessingRequest request) {
+        return withRetry(() -> {
         Map<String, Object> payload = new HashMap<>();
         payload.put("job_id", request.jobId());
         payload.put("video_url", request.videoUrl());
@@ -96,10 +104,12 @@ public class AIServiceHttpAdapter implements AIServicePort {
         } catch (Exception ex) {
             throw new VideoProcessingException("AI service unexpected error", ex);
         }
+        }, MAX_RETRIES);
     }
 
     @Override
     public AIScanSubjectsResponse scanSubjects(AIScanSubjectsRequest request) {
+        return withRetry(() -> {
         Map<String, Object> payload = new HashMap<>();
         payload.put("video_url", request.videoUrl());
         payload.put("min_appearance_ratio", request.minAppearanceRatio());
@@ -129,6 +139,7 @@ public class AIServiceHttpAdapter implements AIServicePort {
         } catch (Exception ex) {
             throw new VideoProcessingException("AI scan unexpected error", ex);
         }
+        }, MAX_RETRIES);
     }
 
     @Override
@@ -162,6 +173,30 @@ public class AIServiceHttpAdapter implements AIServicePort {
             );
         } catch (Exception ex) {
             throw new VideoProcessingException("AI healthcheck error", ex);
+        }
+    }
+
+    private <T> T withRetry(java.util.function.Supplier<T> action, int maxRetries) {
+        int attempt = 0;
+        while (true) {
+            try {
+                return action.get();
+            } catch (VideoProcessingException ex) {
+                boolean is5xx = ex.getCause() instanceof HttpStatusCodeException hsce &&
+                        hsce.getStatusCode().is5xxServerError();
+                if (is5xx && attempt < maxRetries) {
+                    attempt++;
+                    log.warn("Reintentando llamada a IA, intento {}/{}", attempt, maxRetries);
+                    try {
+                        Thread.sleep(500L * attempt);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw ex;
+                    }
+                } else {
+                    throw ex;
+                }
+            }
         }
     }
 

--- a/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapterTest.java
+++ b/backend/src/test/java/com/scalevision/backend/infrastructure/adapter/out/ai/AIServiceHttpAdapterTest.java
@@ -1,0 +1,88 @@
+package com.scalevision.backend.infrastructure.adapter.out.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scalevision.backend.application.exception.VideoProcessingException;
+import com.scalevision.backend.application.port.out.dto.AIProcessingRequest;
+import com.scalevision.backend.application.port.out.dto.AIProcessingResponse;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AIServiceHttpAdapterTest {
+    private MockWebServer mockWebServer;
+    private AIServiceHttpAdapter adapter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        String baseUrl = mockWebServer.url("/svmvp").toString();
+        if (baseUrl.endsWith("/")) baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        adapter = new AIServiceHttpAdapter(baseUrl, 1000, 1000, new ObjectMapper());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void deberiaRetornarRespuestaExitosa() throws Exception {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(202)
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"ai_task_id\":\"ai-001\",\"status\":\"accepted\"}"));
+
+        AIProcessingResponse response = adapter.processVideo(validRequest());
+
+        assertEquals("ai-001", response.aiTaskId());
+        assertEquals("accepted", response.status());
+    }
+
+    @Test
+    void deberiaLanzarExcepcionCon400() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(400));
+
+        assertThrows(VideoProcessingException.class, () -> adapter.processVideo(validRequest()));
+    }
+
+    @Test
+    void deberiaLanzarExcepcionCon500SinReintentar() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        assertThrows(VideoProcessingException.class, () -> adapter.processVideo(validRequest()));
+        assertEquals(3, mockWebServer.getRequestCount());
+    }
+
+    @Test
+    void deberiaNoReintentarCon400() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(400));
+
+        assertThrows(VideoProcessingException.class, () -> adapter.processVideo(validRequest()));
+        assertEquals(1, mockWebServer.getRequestCount());
+    }
+
+    private AIProcessingRequest validRequest() {
+        return new AIProcessingRequest(
+                "job-001",
+                "https://cdn.test/video.mp4",
+                "9:16",
+                30,
+                "center",
+                "http://localhost:8080/svmvp/callbacks/ai",
+                "sv_secret",
+                "auto",
+                null,
+                null,
+                30,
+                false
+        );
+    }
+}


### PR DESCRIPTION
- Agrega withRetry() con MAX_RETRIES=2 y backoff de 500ms
- Reintenta solo errores 5xx, no reintenta 4xx
- Agrega Logger SLF4J para monitorear reintentos
- Crea AIServiceHttpAdapterTest con 4 tests usando MockWebServer

Closes #14