### PR TITLE
feat(config): agregar CorsConfig y RestTemplateConfig con interceptor…

### DIFF
--- a/backend/src/main/java/com/scalevision/backend/infrastructure/config/CorsConfig.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/config/CorsConfig.java
@@ -1,0 +1,21 @@
+package com.scalevision.backend.infrastructure.config;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+/**
+ * Configuración CORS para permitir peticiones desde el frontend.
+ */
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/infrastructure/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/scalevision/backend/infrastructure/config/RestTemplateConfig.java
@@ -1,0 +1,50 @@
+package com.scalevision.backend.infrastructure.config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+
+/**
+ * Configuración centralizada del cliente HTTP RestTemplate.
+ */
+@Configuration
+public class RestTemplateConfig {
+    private static final Logger log = LoggerFactory.getLogger(RestTemplateConfig.class);
+
+    @Bean
+    public RestTemplate restTemplate() {
+
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(2000);
+        factory.setReadTimeout(5000);
+
+        RestTemplate restTemplate = new RestTemplate(factory);
+        restTemplate.setInterceptors(List.of(loggingInterceptor()));
+        return restTemplate;
+    }
+
+    /**
+     * Interceptor de logging que registra el método HTTP, la URI
+     * y el código de respuesta de cada petición saliente.
+     */
+    private ClientHttpRequestInterceptor loggingInterceptor() {
+        return (HttpRequest request, byte[] body, ClientHttpRequestExecution execution) -> {
+            log.debug("HTTP {} {}", request.getMethod(), request.getURI());
+            ClientHttpResponse response = execution.execute(request, body);
+            log.debug("HTTP Response: {}", response.getStatusCode());
+            return response;
+        };
+    }
+}
+
+


### PR DESCRIPTION
… de logging (#15)

- CorsConfig permite peticiones desde http://localhost:3000
- Permite metodos GET, POST, PUT, DELETE, OPTIONS
- RestTemplateConfig centraliza cliente HTTP con timeout de 2s conexion y 5s lectura
- Agrega interceptor de logging para registrar metodo, URI y codigo de respuesta

Closes #15