### PR TITLE
[BACKEND][MVC] Upload real + storage local + contrato FE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Maven
+**/target/
+
+# IntelliJ
+.idea/
+*.iml
+
+# OS
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Maven
 **/target/
+backend/uploads/
 
 # IntelliJ
 .idea/
@@ -7,3 +8,4 @@
 
 # OS
 .DS_Store
+backend/uploads/

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Proyecto ScaleVision.
 
 El backend MVP para FE esta en:
 
-- `/Users/tinus/Developer/scalevision/backend`
+- `backend/`
 
 Documentacion principal:
 
-- `/Users/tinus/Developer/scalevision/backend/README.md`
+- `backend/README.md`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Scale Vision
-Plataforma orientada a la generación automática de shorts verticales a partir de videos horizontales, utilizando inteligencia artificial para preservar el contenido visual relevante y optimizar la presencia digital de startups, pymes y emprendedores.
+
+Proyecto ScaleVision.
+
+## Backend MVC actual
+
+El backend MVP para FE esta en:
+
+- `/Users/tinus/Developer/scalevision/backend`
+
+Documentacion principal:
+
+- `/Users/tinus/Developer/scalevision/backend/README.md`

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,49 @@
+# ScaleVision Backend MVC (MVP)
+
+Backend en Java 21 + Spring Boot 3 para flujo de videos con polling.
+
+## Estructura MVC
+
+- `controller/`: expone endpoints REST para FE.
+- `service/`: reglas de negocio y transiciones de estado.
+- `repository/`: acceso a H2 con Spring Data JPA.
+- `entity/`: modelo `VideoPoc` y enum `VideoStatus`.
+- `dto/`: contratos request/response.
+- `config/`: CORS y manejo global de errores.
+
+## Requisitos
+
+- Java 21
+- Maven 3.9+
+
+## Ejecutar local
+
+```bash
+cd /Users/tinus/Developer/scalevision/backend
+mvn clean spring-boot:run
+```
+
+Base URL local:
+
+- `http://localhost:8080/svmvp`
+
+H2 Console:
+
+- `http://localhost:8080/svmvp/h2-console`
+- JDBC URL: `jdbc:h2:mem:scalevisionmvc`
+- User: `sa`
+- Password: vacio
+
+## Endpoints FE
+
+Ver contrato completo en:
+
+- `/Users/tinus/Developer/scalevision/backend/docs/API_CONTRACT_FE.md`
+
+## Flujo (polling)
+
+1. FE llama `POST /videos/subir`.
+2. FE hace polling a `GET /videos/estado/{id}` cada 3-5s.
+3. Cuando llega a `PROCESADO`, FE consulta `GET /videos/mini-vistas/{id}`.
+4. FE envía mini-vista elegida con `POST /videos/cortar-video/{id}`.
+5. FE hace polling a `GET /videos/final/{id}` hasta obtener `CORTADO`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,7 +19,7 @@ Backend en Java 21 + Spring Boot 3 para flujo de videos con polling.
 ## Ejecutar local
 
 ```bash
-cd /Users/tinus/Developer/scalevision/backend
+cd backend
 mvn clean spring-boot:run
 ```
 
@@ -38,7 +38,7 @@ H2 Console:
 
 Ver contrato completo en:
 
-- `/Users/tinus/Developer/scalevision/backend/docs/API_CONTRACT_FE.md`
+- `docs/API_CONTRACT_FE.md`
 
 ## Flujo (polling)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -40,10 +40,18 @@ Ver contrato completo en:
 
 - `docs/API_CONTRACT_FE.md`
 
+Lista rapida (URL completa):
+
+- `POST http://localhost:8080/svmvp/videos/subir`
+- `GET http://localhost:8080/svmvp/videos/estado/{id}`
+- `GET http://localhost:8080/svmvp/videos/mini-vistas/{id}`
+- `POST http://localhost:8080/svmvp/videos/cortar-video/{id}`
+- `GET http://localhost:8080/svmvp/videos/final/{id}`
+
 ## Flujo (polling)
 
-1. FE llama `POST /videos/subir`.
-2. FE hace polling a `GET /videos/estado/{id}` cada 3-5s.
-3. Cuando llega a `PROCESADO`, FE consulta `GET /videos/mini-vistas/{id}`.
-4. FE envía mini-vista elegida con `POST /videos/cortar-video/{id}`.
-5. FE hace polling a `GET /videos/final/{id}` hasta obtener `CORTADO`.
+1. FE llama `POST http://localhost:8080/svmvp/videos/subir` (multipart/form-data con archivo).
+2. FE hace polling a `GET http://localhost:8080/svmvp/videos/estado/{id}` cada 3-5s.
+3. Cuando llega a `PROCESADO`, FE consulta `GET http://localhost:8080/svmvp/videos/mini-vistas/{id}`.
+4. FE envía mini-vista elegida con `POST http://localhost:8080/svmvp/videos/cortar-video/{id}`.
+5. FE hace polling a `GET http://localhost:8080/svmvp/videos/final/{id}` hasta obtener `CORTADO`.

--- a/backend/docs/API_CONTRACT_FE.md
+++ b/backend/docs/API_CONTRACT_FE.md
@@ -1,0 +1,119 @@
+# Contrato API FE - Backend MVC
+
+Base URL:
+
+- `http://localhost:8080/svmvp`
+
+## 1) Subir video
+
+- **POST** `/videos/subir`
+
+Request:
+
+```json
+{
+  "nombre": "mi-video-demo",
+  "nickname": "cliente1",
+  "tamano": 50.0,
+  "formato": "mp4",
+  "duracion": 60
+}
+```
+
+Response `201`:
+
+```json
+{
+  "id": 1,
+  "urlVideoOriginal": "https://cdn.scalevision.local/videos/1/mi-video-demo.mp4",
+  "estado": "SUBIDO"
+}
+```
+
+## 2) Estado de procesamiento (polling)
+
+- **GET** `/videos/estado/{id}`
+
+Response `200`:
+
+```json
+{
+  "id": 1,
+  "estado": "PROCESANDO",
+  "error": null
+}
+```
+
+## 3) Obtener mini-vistas
+
+- **GET** `/videos/mini-vistas/{id}`
+
+Response `200`:
+
+```json
+{
+  "id": 1,
+  "estado": "PROCESADO",
+  "urlMiniVista01": "https://cdn.scalevision.local/videos/1/mini-1.jpg",
+  "urlMiniVista02": "https://cdn.scalevision.local/videos/1/mini-2.jpg",
+  "urlMiniVista03": "https://cdn.scalevision.local/videos/1/mini-3.jpg"
+}
+```
+
+## 4) Cortar video
+
+- **POST** `/videos/cortar-video/{id}`
+
+Request:
+
+```json
+{
+  "urlMiniVista": "https://cdn.scalevision.local/videos/1/mini-2.jpg"
+}
+```
+
+Response `200`:
+
+```json
+{
+  "id": 1,
+  "estado": "CORTANDO",
+  "urlVistaSeleccionada": "https://cdn.scalevision.local/videos/1/mini-2.jpg"
+}
+```
+
+## 5) Obtener video final (polling)
+
+- **GET** `/videos/final/{id}`
+
+Response `200`:
+
+```json
+{
+  "id": 1,
+  "estado": "CORTADO",
+  "urlVideoFinal": "https://cdn.scalevision.local/videos/1/final-vertical.mp4"
+}
+```
+
+## Estados (enum)
+
+- `SUBIDO`
+- `PROCESANDO`
+- `PROCESADO`
+- `CORTAR`
+- `CORTANDO`
+- `CORTADO`
+- `ERROR`
+
+## Errores
+
+Formato:
+
+```json
+{
+  "code": "BAD_REQUEST",
+  "message": "detalle del error",
+  "timestamp": "2026-02-27T10:30:00"
+}
+```

--- a/backend/docs/API_CONTRACT_FE.md
+++ b/backend/docs/API_CONTRACT_FE.md
@@ -6,19 +6,13 @@ Base URL:
 
 ## 1) Subir video
 
-- **POST** `/videos/subir`
+- **POST** `http://localhost:8080/svmvp/videos/subir`
 
-Request:
+Request (`multipart/form-data`):
 
-```json
-{
-  "nombre": "mi-video-demo",
-  "nickname": "cliente1",
-  "tamano": 50.0,
-  "formato": "mp4",
-  "duracion": 60
-}
-```
+- `video`: archivo de video (obligatorio)
+- `nickname`: texto (opcional)
+- `duracion`: numero entero en segundos (opcional)
 
 Response `201`:
 
@@ -32,7 +26,7 @@ Response `201`:
 
 ## 2) Estado de procesamiento (polling)
 
-- **GET** `/videos/estado/{id}`
+- **GET** `http://localhost:8080/svmvp/videos/estado/{id}`
 
 Response `200`:
 
@@ -46,7 +40,7 @@ Response `200`:
 
 ## 3) Obtener mini-vistas
 
-- **GET** `/videos/mini-vistas/{id}`
+- **GET** `http://localhost:8080/svmvp/videos/mini-vistas/{id}`
 
 Response `200`:
 
@@ -62,7 +56,7 @@ Response `200`:
 
 ## 4) Cortar video
 
-- **POST** `/videos/cortar-video/{id}`
+- **POST** `http://localhost:8080/svmvp/videos/cortar-video/{id}`
 
 Request:
 
@@ -84,7 +78,7 @@ Response `200`:
 
 ## 5) Obtener video final (polling)
 
-- **GET** `/videos/final/{id}`
+- **GET** `http://localhost:8080/svmvp/videos/final/{id}`
 
 Response `200`:
 

--- a/backend/docs/API_CONTRACT_FE.md
+++ b/backend/docs/API_CONTRACT_FE.md
@@ -113,7 +113,13 @@ Formato:
 ```json
 {
   "code": "BAD_REQUEST",
-  "message": "detalle del error",
+  "status": 400,
+  "message": "detalle tecnico del error",
+  "userMessage": "mensaje amigable para FE/usuario",
+  "details": ["campo: descripcion del error"],
+  "suggestion": "accion recomendada",
+  "path": "/svmvp/videos/estado/99",
+  "requestId": "0f4f0a25-27f7-4f37-8b1e-35ce784dca6e",
   "timestamp": "2026-02-27T10:30:00"
 }
 ```

--- a/backend/docs/H2_DATABASE.md
+++ b/backend/docs/H2_DATABASE.md
@@ -1,0 +1,32 @@
+# Modelo H2 - VideoPoc
+
+## Entidad principal
+
+```mermaid
+erDiagram
+    VIDEOS {
+        BIGINT id PK
+        VARCHAR nombre
+        VARCHAR nickname
+        DOUBLE tamano
+        VARCHAR formato
+        INT duracion
+        VARCHAR estado
+        VARCHAR error
+        DATETIME fecha
+        VARCHAR url_video_original
+        VARCHAR url_mini_vista_01
+        VARCHAR url_mini_vista_02
+        VARCHAR url_mini_vista_03
+        VARCHAR url_vista_seleccionada
+        VARCHAR url_video_original_cortado
+        BOOLEAN activo
+    }
+```
+
+## Notas
+
+- Tabla: `videos`
+- BD en memoria: `jdbc:h2:mem:scalevisionmvc`
+- `estado` usa enum `VideoStatus`.
+- `activo` queda en `true` por default.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.scalevision</groupId>
+    <artifactId>backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>scalevision-backend-mvc</name>
+    <description>Backend MVC para ScaleVision MVP</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-junit-jupiter</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/scalevision/backend/BackendMvcApplication.java
+++ b/backend/src/main/java/com/scalevision/backend/BackendMvcApplication.java
@@ -1,0 +1,12 @@
+package com.scalevision.backend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendMvcApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BackendMvcApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/scalevision/backend/config/GlobalExceptionHandler.java
@@ -3,45 +3,100 @@ package com.scalevision.backend.config;
 import com.scalevision.backend.dto.ErrorResponse;
 import com.scalevision.backend.exception.BadRequestException;
 import com.scalevision.backend.exception.ResourceNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleNotFound(ResourceNotFoundException ex) {
+    public ResponseEntity<ErrorResponse> handleNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse("NOT_FOUND", ex.getMessage()));
+                .body(buildError(
+                        "NOT_FOUND",
+                        HttpStatus.NOT_FOUND,
+                        ex.getMessage(),
+                        "No encontramos el recurso solicitado.",
+                        List.of(ex.getMessage()),
+                        "Verifica el identificador e intenta de nuevo.",
+                        request
+                ));
     }
 
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<ErrorResponse> handleBadRequest(BadRequestException ex) {
+    public ResponseEntity<ErrorResponse> handleBadRequest(BadRequestException ex, HttpServletRequest request) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse("BAD_REQUEST", ex.getMessage()));
+                .body(buildError(
+                        "BAD_REQUEST",
+                        HttpStatus.BAD_REQUEST,
+                        ex.getMessage(),
+                        "La solicitud no es valida para el estado actual del video.",
+                        List.of(ex.getMessage()),
+                        "Revisa los datos enviados y vuelve a intentar.",
+                        request
+                ));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
-        String message = ex.getBindingResult()
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        List<String> details = ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining("; "));
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.toList());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse("VALIDATION_ERROR", message));
+                .body(buildError(
+                        "VALIDATION_ERROR",
+                        HttpStatus.BAD_REQUEST,
+                        "Error de validacion en la solicitud",
+                        "Uno o mas campos tienen valores invalidos.",
+                        details,
+                        "Corrige los campos indicados y vuelve a enviar la peticion.",
+                        request
+                ));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneric(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleGeneric(Exception ex, HttpServletRequest request) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse("INTERNAL_ERROR", "Error inesperado en el servidor"));
+                .body(buildError(
+                        "INTERNAL_ERROR",
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        "Error inesperado en el servidor",
+                        "Tuvimos un problema interno al procesar tu solicitud.",
+                        List.of(ex.getClass().getSimpleName()),
+                        "Intenta de nuevo en unos segundos. Si persiste, contacta soporte.",
+                        request
+                ));
+    }
+
+    private ErrorResponse buildError(
+            String code,
+            HttpStatus status,
+            String message,
+            String userMessage,
+            List<String> details,
+            String suggestion,
+            HttpServletRequest request
+    ) {
+        return new ErrorResponse(
+                code,
+                status.value(),
+                message,
+                userMessage,
+                details,
+                suggestion,
+                request.getRequestURI(),
+                UUID.randomUUID().toString()
+        );
     }
 }

--- a/backend/src/main/java/com/scalevision/backend/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/scalevision/backend/config/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package com.scalevision.backend.config;
+
+import com.scalevision.backend.dto.ErrorResponse;
+import com.scalevision.backend.exception.BadRequestException;
+import com.scalevision.backend.exception.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("NOT_FOUND", ex.getMessage()));
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(BadRequestException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("BAD_REQUEST", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining("; "));
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("VALIDATION_ERROR", message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneric(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse("INTERNAL_ERROR", "Error inesperado en el servidor"));
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/scalevision/backend/config/WebConfig.java
@@ -3,7 +3,11 @@ package com.scalevision.backend.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -11,11 +15,21 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${app.cors.allowed-origins}")
     private String allowedOrigins;
 
+    @Value("${app.storage.upload-dir:uploads}")
+    private String uploadDir;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*");
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:" + uploadPath + "/");
     }
 }

--- a/backend/src/main/java/com/scalevision/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/scalevision/backend/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.scalevision.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${app.cors.allowed-origins}")
+    private String allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(allowedOrigins)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+                .allowedHeaders("*");
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/controller/VideoController.java
+++ b/backend/src/main/java/com/scalevision/backend/controller/VideoController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -38,9 +38,9 @@ public class VideoController {
 
     @PostMapping(value = "/subir", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UploadVideoResponse> subirVideoArchivo(
-            @RequestPart("video") MultipartFile video,
-            @RequestPart(value = "nickname", required = false) String nickname,
-            @RequestPart(value = "duracion", required = false) Integer duracion
+            @RequestParam("video") MultipartFile video,
+            @RequestParam(value = "nickname", required = false) String nickname,
+            @RequestParam(value = "duracion", required = false) Integer duracion
     ) {
         return ResponseEntity.status(HttpStatus.CREATED).body(videoService.subirVideoArchivo(video, nickname, duracion));
     }

--- a/backend/src/main/java/com/scalevision/backend/controller/VideoController.java
+++ b/backend/src/main/java/com/scalevision/backend/controller/VideoController.java
@@ -1,0 +1,58 @@
+package com.scalevision.backend.controller;
+
+import com.scalevision.backend.dto.CortarVideoRequest;
+import com.scalevision.backend.dto.CortarVideoResponse;
+import com.scalevision.backend.dto.EstadoVideoResponse;
+import com.scalevision.backend.dto.MiniVistasResponse;
+import com.scalevision.backend.dto.UploadVideoRequest;
+import com.scalevision.backend.dto.UploadVideoResponse;
+import com.scalevision.backend.dto.VideoFinalResponse;
+import com.scalevision.backend.service.VideoService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/videos")
+public class VideoController {
+
+    private final VideoService videoService;
+
+    public VideoController(VideoService videoService) {
+        this.videoService = videoService;
+    }
+
+    @PostMapping("/subir")
+    public ResponseEntity<UploadVideoResponse> subirVideo(@Valid @RequestBody UploadVideoRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(videoService.subirVideo(request));
+    }
+
+    @GetMapping("/estado/{id}")
+    public ResponseEntity<EstadoVideoResponse> obtenerEstado(@PathVariable Long id) {
+        return ResponseEntity.ok(videoService.obtenerEstado(id));
+    }
+
+    @GetMapping("/mini-vistas/{id}")
+    public ResponseEntity<MiniVistasResponse> obtenerMiniVistas(@PathVariable Long id) {
+        return ResponseEntity.ok(videoService.obtenerMiniVistas(id));
+    }
+
+    @PostMapping("/cortar-video/{id}")
+    public ResponseEntity<CortarVideoResponse> cortarVideo(
+            @PathVariable Long id,
+            @Valid @RequestBody CortarVideoRequest request
+    ) {
+        return ResponseEntity.ok(videoService.cortarVideo(id, request));
+    }
+
+    @GetMapping("/final/{id}")
+    public ResponseEntity<VideoFinalResponse> obtenerFinal(@PathVariable Long id) {
+        return ResponseEntity.ok(videoService.obtenerVideoFinal(id));
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/controller/VideoController.java
+++ b/backend/src/main/java/com/scalevision/backend/controller/VideoController.java
@@ -9,14 +9,17 @@ import com.scalevision.backend.dto.UploadVideoResponse;
 import com.scalevision.backend.dto.VideoFinalResponse;
 import com.scalevision.backend.service.VideoService;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/videos")
@@ -28,9 +31,18 @@ public class VideoController {
         this.videoService = videoService;
     }
 
-    @PostMapping("/subir")
+    @PostMapping(value = "/subir", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UploadVideoResponse> subirVideo(@Valid @RequestBody UploadVideoRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(videoService.subirVideo(request));
+    }
+
+    @PostMapping(value = "/subir", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UploadVideoResponse> subirVideoArchivo(
+            @RequestPart("video") MultipartFile video,
+            @RequestPart(value = "nickname", required = false) String nickname,
+            @RequestPart(value = "duracion", required = false) Integer duracion
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(videoService.subirVideoArchivo(video, nickname, duracion));
     }
 
     @GetMapping("/estado/{id}")

--- a/backend/src/main/java/com/scalevision/backend/dto/CortarVideoRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/CortarVideoRequest.java
@@ -1,0 +1,17 @@
+package com.scalevision.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CortarVideoRequest {
+
+    @NotBlank(message = "Debe enviar la mini-vista seleccionada")
+    private String urlMiniVista;
+
+    public String getUrlMiniVista() {
+        return urlMiniVista;
+    }
+
+    public void setUrlMiniVista(String urlMiniVista) {
+        this.urlMiniVista = urlMiniVista;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/dto/CortarVideoResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/CortarVideoResponse.java
@@ -1,0 +1,26 @@
+package com.scalevision.backend.dto;
+
+public class CortarVideoResponse {
+
+    private Long id;
+    private String estado;
+    private String urlVistaSeleccionada;
+
+    public CortarVideoResponse(Long id, String estado, String urlVistaSeleccionada) {
+        this.id = id;
+        this.estado = estado;
+        this.urlVistaSeleccionada = urlVistaSeleccionada;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public String getUrlVistaSeleccionada() {
+        return urlVistaSeleccionada;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/ErrorResponse.java
@@ -1,16 +1,38 @@
 package com.scalevision.backend.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ErrorResponse {
 
     private String code;
+    private Integer status;
     private String message;
+    private String userMessage;
+    private List<String> details;
+    private String suggestion;
+    private String path;
+    private String requestId;
     private LocalDateTime timestamp;
 
-    public ErrorResponse(String code, String message) {
+    public ErrorResponse(
+            String code,
+            Integer status,
+            String message,
+            String userMessage,
+            List<String> details,
+            String suggestion,
+            String path,
+            String requestId
+    ) {
         this.code = code;
+        this.status = status;
         this.message = message;
+        this.userMessage = userMessage;
+        this.details = details;
+        this.suggestion = suggestion;
+        this.path = path;
+        this.requestId = requestId;
         this.timestamp = LocalDateTime.now();
     }
 
@@ -18,8 +40,32 @@ public class ErrorResponse {
         return code;
     }
 
+    public Integer getStatus() {
+        return status;
+    }
+
     public String getMessage() {
         return message;
+    }
+
+    public String getUserMessage() {
+        return userMessage;
+    }
+
+    public List<String> getDetails() {
+        return details;
+    }
+
+    public String getSuggestion() {
+        return suggestion;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getRequestId() {
+        return requestId;
     }
 
     public LocalDateTime getTimestamp() {

--- a/backend/src/main/java/com/scalevision/backend/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.scalevision.backend.dto;
+
+import java.time.LocalDateTime;
+
+public class ErrorResponse {
+
+    private String code;
+    private String message;
+    private LocalDateTime timestamp;
+
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/dto/EstadoVideoResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/EstadoVideoResponse.java
@@ -1,0 +1,26 @@
+package com.scalevision.backend.dto;
+
+public class EstadoVideoResponse {
+
+    private Long id;
+    private String estado;
+    private String error;
+
+    public EstadoVideoResponse(Long id, String estado, String error) {
+        this.id = id;
+        this.estado = estado;
+        this.error = error;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public String getError() {
+        return error;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/dto/MiniVistasResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/MiniVistasResponse.java
@@ -1,0 +1,38 @@
+package com.scalevision.backend.dto;
+
+public class MiniVistasResponse {
+
+    private Long id;
+    private String estado;
+    private String urlMiniVista01;
+    private String urlMiniVista02;
+    private String urlMiniVista03;
+
+    public MiniVistasResponse(Long id, String estado, String urlMiniVista01, String urlMiniVista02, String urlMiniVista03) {
+        this.id = id;
+        this.estado = estado;
+        this.urlMiniVista01 = urlMiniVista01;
+        this.urlMiniVista02 = urlMiniVista02;
+        this.urlMiniVista03 = urlMiniVista03;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public String getUrlMiniVista01() {
+        return urlMiniVista01;
+    }
+
+    public String getUrlMiniVista02() {
+        return urlMiniVista02;
+    }
+
+    public String getUrlMiniVista03() {
+        return urlMiniVista03;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/dto/UploadVideoRequest.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/UploadVideoRequest.java
@@ -1,0 +1,59 @@
+package com.scalevision.backend.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+
+public class UploadVideoRequest {
+
+    @NotBlank(message = "El nombre del video es obligatorio")
+    private String nombre;
+
+    private String nickname;
+
+    @DecimalMin(value = "0.1", message = "El tamano debe ser mayor a 0")
+    private Double tamano;
+
+    private String formato;
+
+    private Integer duracion;
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public Double getTamano() {
+        return tamano;
+    }
+
+    public void setTamano(Double tamano) {
+        this.tamano = tamano;
+    }
+
+    public String getFormato() {
+        return formato;
+    }
+
+    public void setFormato(String formato) {
+        this.formato = formato;
+    }
+
+    public Integer getDuracion() {
+        return duracion;
+    }
+
+    public void setDuracion(Integer duracion) {
+        this.duracion = duracion;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/dto/UploadVideoResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/UploadVideoResponse.java
@@ -1,0 +1,26 @@
+package com.scalevision.backend.dto;
+
+public class UploadVideoResponse {
+
+    private Long id;
+    private String urlVideoOriginal;
+    private String estado;
+
+    public UploadVideoResponse(Long id, String urlVideoOriginal, String estado) {
+        this.id = id;
+        this.urlVideoOriginal = urlVideoOriginal;
+        this.estado = estado;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUrlVideoOriginal() {
+        return urlVideoOriginal;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/dto/VideoFinalResponse.java
+++ b/backend/src/main/java/com/scalevision/backend/dto/VideoFinalResponse.java
@@ -1,0 +1,26 @@
+package com.scalevision.backend.dto;
+
+public class VideoFinalResponse {
+
+    private Long id;
+    private String estado;
+    private String urlVideoFinal;
+
+    public VideoFinalResponse(Long id, String estado, String urlVideoFinal) {
+        this.id = id;
+        this.estado = estado;
+        this.urlVideoFinal = urlVideoFinal;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public String getUrlVideoFinal() {
+        return urlVideoFinal;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/entity/VideoPoc.java
+++ b/backend/src/main/java/com/scalevision/backend/entity/VideoPoc.java
@@ -1,0 +1,204 @@
+package com.scalevision.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "videos")
+public class VideoPoc {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nombre;
+
+    private String nickname;
+
+    @Column(nullable = false)
+    private Double tamano;
+
+    @Column(nullable = false)
+    private String formato;
+
+    @Column(nullable = false)
+    private Integer duracion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VideoStatus estado;
+
+    private String error;
+
+    @Column(nullable = false)
+    private LocalDateTime fecha;
+
+    @Column(name = "url_video_original")
+    private String urlVideoOriginal;
+
+    @Column(name = "url_mini_vista_01")
+    private String urlMiniVista01;
+
+    @Column(name = "url_mini_vista_02")
+    private String urlMiniVista02;
+
+    @Column(name = "url_mini_vista_03")
+    private String urlMiniVista03;
+
+    @Column(name = "url_vista_seleccionada")
+    private String urlVistaSeleccionada;
+
+    @Column(name = "url_video_original_cortado")
+    private String urlVideoOriginalCortado;
+
+    @Column(nullable = false)
+    private Boolean activo;
+
+    @PrePersist
+    public void prePersist() {
+        if (activo == null) {
+            activo = true;
+        }
+        if (fecha == null) {
+            fecha = LocalDateTime.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public Double getTamano() {
+        return tamano;
+    }
+
+    public void setTamano(Double tamano) {
+        this.tamano = tamano;
+    }
+
+    public String getFormato() {
+        return formato;
+    }
+
+    public void setFormato(String formato) {
+        this.formato = formato;
+    }
+
+    public Integer getDuracion() {
+        return duracion;
+    }
+
+    public void setDuracion(Integer duracion) {
+        this.duracion = duracion;
+    }
+
+    public VideoStatus getEstado() {
+        return estado;
+    }
+
+    public void setEstado(VideoStatus estado) {
+        this.estado = estado;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public LocalDateTime getFecha() {
+        return fecha;
+    }
+
+    public void setFecha(LocalDateTime fecha) {
+        this.fecha = fecha;
+    }
+
+    public String getUrlVideoOriginal() {
+        return urlVideoOriginal;
+    }
+
+    public void setUrlVideoOriginal(String urlVideoOriginal) {
+        this.urlVideoOriginal = urlVideoOriginal;
+    }
+
+    public String getUrlMiniVista01() {
+        return urlMiniVista01;
+    }
+
+    public void setUrlMiniVista01(String urlMiniVista01) {
+        this.urlMiniVista01 = urlMiniVista01;
+    }
+
+    public String getUrlMiniVista02() {
+        return urlMiniVista02;
+    }
+
+    public void setUrlMiniVista02(String urlMiniVista02) {
+        this.urlMiniVista02 = urlMiniVista02;
+    }
+
+    public String getUrlMiniVista03() {
+        return urlMiniVista03;
+    }
+
+    public void setUrlMiniVista03(String urlMiniVista03) {
+        this.urlMiniVista03 = urlMiniVista03;
+    }
+
+    public String getUrlVistaSeleccionada() {
+        return urlVistaSeleccionada;
+    }
+
+    public void setUrlVistaSeleccionada(String urlVistaSeleccionada) {
+        this.urlVistaSeleccionada = urlVistaSeleccionada;
+    }
+
+    public String getUrlVideoOriginalCortado() {
+        return urlVideoOriginalCortado;
+    }
+
+    public void setUrlVideoOriginalCortado(String urlVideoOriginalCortado) {
+        this.urlVideoOriginalCortado = urlVideoOriginalCortado;
+    }
+
+    public Boolean getActivo() {
+        return activo;
+    }
+
+    public void setActivo(Boolean activo) {
+        this.activo = activo;
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/entity/VideoPoc.java
+++ b/backend/src/main/java/com/scalevision/backend/entity/VideoPoc.java
@@ -46,6 +46,9 @@ public class VideoPoc {
     @Column(name = "url_video_original")
     private String urlVideoOriginal;
 
+    @Column(name = "ruta_archivo_local")
+    private String rutaArchivoLocal;
+
     @Column(name = "url_mini_vista_01")
     private String urlMiniVista01;
 
@@ -152,6 +155,14 @@ public class VideoPoc {
 
     public void setUrlVideoOriginal(String urlVideoOriginal) {
         this.urlVideoOriginal = urlVideoOriginal;
+    }
+
+    public String getRutaArchivoLocal() {
+        return rutaArchivoLocal;
+    }
+
+    public void setRutaArchivoLocal(String rutaArchivoLocal) {
+        this.rutaArchivoLocal = rutaArchivoLocal;
     }
 
     public String getUrlMiniVista01() {

--- a/backend/src/main/java/com/scalevision/backend/entity/VideoStatus.java
+++ b/backend/src/main/java/com/scalevision/backend/entity/VideoStatus.java
@@ -1,0 +1,11 @@
+package com.scalevision.backend.entity;
+
+public enum VideoStatus {
+    SUBIDO,
+    PROCESANDO,
+    PROCESADO,
+    CORTAR,
+    CORTANDO,
+    CORTADO,
+    ERROR
+}

--- a/backend/src/main/java/com/scalevision/backend/exception/BadRequestException.java
+++ b/backend/src/main/java/com/scalevision/backend/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.scalevision.backend.exception;
+
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/scalevision/backend/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.scalevision.backend.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/repository/VideoRepository.java
+++ b/backend/src/main/java/com/scalevision/backend/repository/VideoRepository.java
@@ -1,0 +1,7 @@
+package com.scalevision.backend.repository;
+
+import com.scalevision.backend.entity.VideoPoc;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VideoRepository extends JpaRepository<VideoPoc, Long> {
+}

--- a/backend/src/main/java/com/scalevision/backend/service/VideoService.java
+++ b/backend/src/main/java/com/scalevision/backend/service/VideoService.java
@@ -1,0 +1,147 @@
+package com.scalevision.backend.service;
+
+import com.scalevision.backend.dto.CortarVideoRequest;
+import com.scalevision.backend.dto.CortarVideoResponse;
+import com.scalevision.backend.dto.EstadoVideoResponse;
+import com.scalevision.backend.dto.MiniVistasResponse;
+import com.scalevision.backend.dto.UploadVideoRequest;
+import com.scalevision.backend.dto.UploadVideoResponse;
+import com.scalevision.backend.dto.VideoFinalResponse;
+import com.scalevision.backend.entity.VideoPoc;
+import com.scalevision.backend.entity.VideoStatus;
+import com.scalevision.backend.exception.BadRequestException;
+import com.scalevision.backend.exception.ResourceNotFoundException;
+import com.scalevision.backend.repository.VideoRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+public class VideoService {
+
+    private final VideoRepository videoRepository;
+
+    public VideoService(VideoRepository videoRepository) {
+        this.videoRepository = videoRepository;
+    }
+
+    public UploadVideoResponse subirVideo(UploadVideoRequest request) {
+        VideoPoc video = new VideoPoc();
+        video.setNombre(request.getNombre());
+        video.setNickname(request.getNickname());
+        video.setTamano(request.getTamano() == null ? 50.0 : request.getTamano());
+        video.setFormato(request.getFormato() == null ? "mp4" : request.getFormato());
+        video.setDuracion(request.getDuracion() == null ? 60 : request.getDuracion());
+        video.setEstado(VideoStatus.SUBIDO);
+        video.setFecha(LocalDateTime.now());
+        video.setActivo(true);
+
+        VideoPoc saved = videoRepository.save(video);
+        saved.setUrlVideoOriginal(buildOriginalUrl(saved.getId(), saved.getNombre(), saved.getFormato()));
+        saved = videoRepository.save(saved);
+
+        return new UploadVideoResponse(saved.getId(), saved.getUrlVideoOriginal(), saved.getEstado().name());
+    }
+
+    public EstadoVideoResponse obtenerEstado(Long id) {
+        VideoPoc video = findVideoOrThrow(id);
+        actualizarFlujoProcesado(video);
+        return new EstadoVideoResponse(video.getId(), video.getEstado().name(), video.getError());
+    }
+
+    public MiniVistasResponse obtenerMiniVistas(Long id) {
+        VideoPoc video = findVideoOrThrow(id);
+        actualizarFlujoProcesado(video);
+
+        if (video.getEstado() != VideoStatus.PROCESADO && video.getEstado() != VideoStatus.CORTAR
+                && video.getEstado() != VideoStatus.CORTANDO && video.getEstado() != VideoStatus.CORTADO) {
+            throw new BadRequestException("El video todavia no tiene mini-vistas disponibles");
+        }
+
+        return new MiniVistasResponse(
+                video.getId(),
+                video.getEstado().name(),
+                video.getUrlMiniVista01(),
+                video.getUrlMiniVista02(),
+                video.getUrlMiniVista03()
+        );
+    }
+
+    public CortarVideoResponse cortarVideo(Long id, CortarVideoRequest request) {
+        VideoPoc video = findVideoOrThrow(id);
+        actualizarFlujoProcesado(video);
+
+        if (video.getEstado() != VideoStatus.PROCESADO && video.getEstado() != VideoStatus.CORTAR) {
+            throw new BadRequestException("Solo se puede cortar un video en estado PROCESADO");
+        }
+
+        video.setUrlVistaSeleccionada(request.getUrlMiniVista());
+        video.setEstado(VideoStatus.CORTANDO);
+        video.setFecha(LocalDateTime.now());
+        videoRepository.save(video);
+
+        return new CortarVideoResponse(video.getId(), video.getEstado().name(), video.getUrlVistaSeleccionada());
+    }
+
+    public VideoFinalResponse obtenerVideoFinal(Long id) {
+        VideoPoc video = findVideoOrThrow(id);
+        actualizarFlujoProcesado(video);
+        actualizarFlujoCorte(video);
+
+        if (video.getEstado() != VideoStatus.CORTADO) {
+            throw new BadRequestException("El video final aun no esta listo");
+        }
+
+        return new VideoFinalResponse(video.getId(), video.getEstado().name(), video.getUrlVideoOriginalCortado());
+    }
+
+    private VideoPoc findVideoOrThrow(Long id) {
+        return videoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("No existe el video con id: " + id));
+    }
+
+    private void actualizarFlujoProcesado(VideoPoc video) {
+        long seconds = ChronoUnit.SECONDS.between(video.getFecha(), LocalDateTime.now());
+
+        if (video.getEstado() == VideoStatus.SUBIDO && seconds >= 2) {
+            video.setEstado(VideoStatus.PROCESANDO);
+            video.setFecha(LocalDateTime.now());
+            videoRepository.save(video);
+            return;
+        }
+
+        if (video.getEstado() == VideoStatus.PROCESANDO && seconds >= 3) {
+            video.setEstado(VideoStatus.PROCESADO);
+            video.setFecha(LocalDateTime.now());
+            generarMiniVistas(video);
+            videoRepository.save(video);
+        }
+    }
+
+    private void actualizarFlujoCorte(VideoPoc video) {
+        long seconds = ChronoUnit.SECONDS.between(video.getFecha(), LocalDateTime.now());
+
+        if (video.getEstado() == VideoStatus.CORTANDO && seconds >= 4) {
+            video.setEstado(VideoStatus.CORTADO);
+            video.setFecha(LocalDateTime.now());
+            video.setUrlVideoOriginalCortado(buildFinalVideoUrl(video.getId()));
+            videoRepository.save(video);
+        }
+    }
+
+    private void generarMiniVistas(VideoPoc video) {
+        video.setUrlMiniVista01("https://cdn.scalevision.local/videos/" + video.getId() + "/mini-1.jpg");
+        video.setUrlMiniVista02("https://cdn.scalevision.local/videos/" + video.getId() + "/mini-2.jpg");
+        video.setUrlMiniVista03("https://cdn.scalevision.local/videos/" + video.getId() + "/mini-3.jpg");
+    }
+
+    private String buildOriginalUrl(Long id, String nombre, String formato) {
+        String safeNombre = nombre.toLowerCase().replace(" ", "-");
+        return "https://cdn.scalevision.local/videos/" + id + "/" + safeNombre + "." + formato;
+    }
+
+    private String buildFinalVideoUrl(Long id) {
+        return "https://cdn.scalevision.local/videos/" + id + "/final-vertical.mp4";
+    }
+}

--- a/backend/src/main/java/com/scalevision/backend/service/VideoService.java
+++ b/backend/src/main/java/com/scalevision/backend/service/VideoService.java
@@ -12,18 +12,37 @@ import com.scalevision.backend.entity.VideoStatus;
 import com.scalevision.backend.exception.BadRequestException;
 import com.scalevision.backend.exception.ResourceNotFoundException;
 import com.scalevision.backend.repository.VideoRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+import java.util.UUID;
 
 @Service
 public class VideoService {
 
     private final VideoRepository videoRepository;
+    private final Path uploadRoot;
 
-    public VideoService(VideoRepository videoRepository) {
+    public VideoService(
+            VideoRepository videoRepository,
+            @Value("${app.storage.upload-dir:uploads}") String uploadDir
+    ) {
         this.videoRepository = videoRepository;
+        this.uploadRoot = Paths.get(uploadDir).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(this.uploadRoot);
+        } catch (IOException ex) {
+            throw new IllegalStateException("No se pudo crear el directorio de uploads", ex);
+        }
     }
 
     public UploadVideoResponse subirVideo(UploadVideoRequest request) {
@@ -39,6 +58,41 @@ public class VideoService {
 
         VideoPoc saved = videoRepository.save(video);
         saved.setUrlVideoOriginal(buildOriginalUrl(saved.getId(), saved.getNombre(), saved.getFormato()));
+        saved = videoRepository.save(saved);
+
+        return new UploadVideoResponse(saved.getId(), saved.getUrlVideoOriginal(), saved.getEstado().name());
+    }
+
+    public UploadVideoResponse subirVideoArchivo(MultipartFile videoFile, String nickname, Integer duracion) {
+        if (videoFile == null || videoFile.isEmpty()) {
+            throw new BadRequestException("Debe enviar un archivo de video");
+        }
+
+        String originalName = videoFile.getOriginalFilename() == null ? "video.mp4" : videoFile.getOriginalFilename();
+        String formato = extraerExtension(originalName);
+        String nombreBase = limpiarNombreSinExtension(originalName);
+        String storedFileName = System.currentTimeMillis() + "-" + UUID.randomUUID() + "." + formato;
+
+        Path destination = uploadRoot.resolve(storedFileName);
+        try {
+            Files.copy(videoFile.getInputStream(), destination, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException ex) {
+            throw new IllegalStateException("No se pudo guardar el archivo de video", ex);
+        }
+
+        VideoPoc video = new VideoPoc();
+        video.setNombre(nombreBase);
+        video.setNickname(nickname);
+        video.setTamano(convertirAMegaBytes(videoFile.getSize()));
+        video.setFormato(formato);
+        video.setDuracion(duracion == null ? 60 : duracion);
+        video.setEstado(VideoStatus.SUBIDO);
+        video.setFecha(LocalDateTime.now());
+        video.setActivo(true);
+        video.setRutaArchivoLocal(destination.toString());
+
+        VideoPoc saved = videoRepository.save(video);
+        saved.setUrlVideoOriginal("http://localhost:8080/svmvp/uploads/" + storedFileName);
         saved = videoRepository.save(saved);
 
         return new UploadVideoResponse(saved.getId(), saved.getUrlVideoOriginal(), saved.getEstado().name());
@@ -143,5 +197,26 @@ public class VideoService {
 
     private String buildFinalVideoUrl(Long id) {
         return "https://cdn.scalevision.local/videos/" + id + "/final-vertical.mp4";
+    }
+
+    private String extraerExtension(String fileName) {
+        int lastDot = fileName.lastIndexOf(".");
+        if (lastDot < 0 || lastDot == fileName.length() - 1) {
+            return "mp4";
+        }
+        return fileName.substring(lastDot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private String limpiarNombreSinExtension(String fileName) {
+        String clean = fileName;
+        int lastDot = fileName.lastIndexOf(".");
+        if (lastDot > 0) {
+            clean = fileName.substring(0, lastDot);
+        }
+        return clean.replace(" ", "-").toLowerCase(Locale.ROOT);
+    }
+
+    private double convertirAMegaBytes(long bytes) {
+        return Math.round((bytes / (1024.0 * 1024.0)) * 100.0) / 100.0;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -20,7 +20,13 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 200MB
+      max-request-size: 200MB
 
 app:
   cors:
     allowed-origins: http://localhost:3000
+  storage:
+    upload-dir: uploads

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+server:
+  port: 8080
+  servlet:
+    context-path: /svmvp
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:scalevisionmvc
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+app:
+  cors:
+    allowed-origins: http://localhost:3000

--- a/backend/src/test/java/com/scalevision/backend/BackendMvcApplicationTests.java
+++ b/backend/src/test/java/com/scalevision/backend/BackendMvcApplicationTests.java
@@ -1,0 +1,12 @@
+package com.scalevision.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendMvcApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/backend/src/test/java/com/scalevision/backend/service/VideoServiceTest.java
+++ b/backend/src/test/java/com/scalevision/backend/service/VideoServiceTest.java
@@ -1,0 +1,35 @@
+package com.scalevision.backend.service;
+
+import com.scalevision.backend.dto.UploadVideoRequest;
+import com.scalevision.backend.dto.UploadVideoResponse;
+import com.scalevision.backend.entity.VideoStatus;
+import com.scalevision.backend.repository.VideoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+class VideoServiceTest {
+
+    @Autowired
+    private VideoService videoService;
+
+    @Autowired
+    private VideoRepository videoRepository;
+
+    @Test
+    void subirVideo_debeGuardarVideoConEstadoSubido() {
+        UploadVideoRequest request = new UploadVideoRequest();
+        request.setNombre("demo-video");
+        request.setTamano(50.0);
+
+        UploadVideoResponse response = videoService.subirVideo(request);
+
+        assertNotNull(response.getId());
+        assertEquals(VideoStatus.SUBIDO.name(), response.getEstado());
+        assertNotNull(videoRepository.findById(response.getId()).orElseThrow().getUrlVideoOriginal());
+    }
+}


### PR DESCRIPTION
## Resumen
Se actualiza el nuevo backend MVC para FE con subida real de video usando multipart/form-data, almacenamiento local en backend y documentación alineada con URL completa + puerto.

## Cambios principales
- Endpoint de subida soporta archivo real:
  - `POST http://localhost:8080/svmvp/videos/subir`
  - Content-Type: `multipart/form-data`
  - Campo obligatorio: `video`
  - Campos opcionales: `nickname`, `duracion`
- Storage local en backend:
  - Carpeta local `uploads/`
  - Persistencia de metadata en H2 (`VideoPoc`)
  - Se guarda ruta local de archivo en BD
- Exposición de archivos subidos:
  - `GET /svmvp/uploads/{filename}`
- Manejo de errores mejorado para FE/usuario:
  - `code, status, message, userMessage, details, suggestion, path, requestId, timestamp`
- Documentación actualizada:
  - Endpoints con URL completa y puerto
  - Contrato FE ajustado a multipart

## Endpoints FE incluidos
- `POST http://localhost:8080/svmvp/videos/subir`
- `GET http://localhost:8080/svmvp/videos/estado/{id}`
- `GET http://localhost:8080/svmvp/videos/mini-vistas/{id}`
- `POST http://localhost:8080/svmvp/videos/cortar-video/{id}`
- `GET http://localhost:8080/svmvp/videos/final/{id}`

## Validación
- `mvn test` OK
- prueba manual de subida real (multipart) OK
