### PR TITLE
[BACKEND][MVC] Upload real + storage por carpetas + contrato FE

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -34,6 +34,12 @@ H2 Console:
 - User: `sa`
 - Password: vacio
 
+Storage local:
+
+- `uploads/originals/` para video original subido.
+- `uploads/finals/` para video final cortado.
+- `uploads/thumbnails/` para mini-vistas.
+
 ## Endpoints FE
 
 Ver contrato completo en:

--- a/backend/docs/API_CONTRACT_FE.md
+++ b/backend/docs/API_CONTRACT_FE.md
@@ -19,7 +19,7 @@ Response `201`:
 ```json
 {
   "id": 1,
-  "urlVideoOriginal": "https://cdn.scalevision.local/videos/1/mi-video-demo.mp4",
+  "urlVideoOriginal": "http://localhost:8080/svmvp/uploads/originals/1740969300000-uuid.mp4",
   "estado": "SUBIDO"
 }
 ```
@@ -48,9 +48,9 @@ Response `200`:
 {
   "id": 1,
   "estado": "PROCESADO",
-  "urlMiniVista01": "https://cdn.scalevision.local/videos/1/mini-1.jpg",
-  "urlMiniVista02": "https://cdn.scalevision.local/videos/1/mini-2.jpg",
-  "urlMiniVista03": "https://cdn.scalevision.local/videos/1/mini-3.jpg"
+  "urlMiniVista01": "http://localhost:8080/svmvp/uploads/thumbnails/1-mini-1.jpg",
+  "urlMiniVista02": "http://localhost:8080/svmvp/uploads/thumbnails/1-mini-2.jpg",
+  "urlMiniVista03": "http://localhost:8080/svmvp/uploads/thumbnails/1-mini-3.jpg"
 }
 ```
 
@@ -62,7 +62,7 @@ Request:
 
 ```json
 {
-  "urlMiniVista": "https://cdn.scalevision.local/videos/1/mini-2.jpg"
+  "urlMiniVista": "http://localhost:8080/svmvp/uploads/thumbnails/1-mini-2.jpg"
 }
 ```
 
@@ -72,7 +72,7 @@ Response `200`:
 {
   "id": 1,
   "estado": "CORTANDO",
-  "urlVistaSeleccionada": "https://cdn.scalevision.local/videos/1/mini-2.jpg"
+  "urlVistaSeleccionada": "http://localhost:8080/svmvp/uploads/thumbnails/1-mini-2.jpg"
 }
 ```
 
@@ -86,9 +86,15 @@ Response `200`:
 {
   "id": 1,
   "estado": "CORTADO",
-  "urlVideoFinal": "https://cdn.scalevision.local/videos/1/final-vertical.mp4"
+  "urlVideoFinal": "http://localhost:8080/svmvp/uploads/finals/1-final-1740969309999.mp4"
 }
 ```
+
+## Estructura de almacenamiento local (BE)
+
+- `uploads/originals/` -> videos subidos por FE.
+- `uploads/finals/` -> videos finales procesados/cortados.
+- `uploads/thumbnails/` -> mini-vistas.
 
 ## Estados (enum)
 

--- a/backend/docs/H2_DATABASE.md
+++ b/backend/docs/H2_DATABASE.md
@@ -15,6 +15,8 @@ erDiagram
         VARCHAR error
         DATETIME fecha
         VARCHAR url_video_original
+        VARCHAR ruta_archivo_local
+        VARCHAR ruta_archivo_local_final
         VARCHAR url_mini_vista_01
         VARCHAR url_mini_vista_02
         VARCHAR url_mini_vista_03

--- a/backend/src/main/java/com/scalevision/backend/entity/VideoPoc.java
+++ b/backend/src/main/java/com/scalevision/backend/entity/VideoPoc.java
@@ -49,6 +49,9 @@ public class VideoPoc {
     @Column(name = "ruta_archivo_local")
     private String rutaArchivoLocal;
 
+    @Column(name = "ruta_archivo_local_final")
+    private String rutaArchivoLocalFinal;
+
     @Column(name = "url_mini_vista_01")
     private String urlMiniVista01;
 
@@ -163,6 +166,14 @@ public class VideoPoc {
 
     public void setRutaArchivoLocal(String rutaArchivoLocal) {
         this.rutaArchivoLocal = rutaArchivoLocal;
+    }
+
+    public String getRutaArchivoLocalFinal() {
+        return rutaArchivoLocalFinal;
+    }
+
+    public void setRutaArchivoLocalFinal(String rutaArchivoLocalFinal) {
+        this.rutaArchivoLocalFinal = rutaArchivoLocalFinal;
     }
 
     public String getUrlMiniVista01() {

--- a/backend/src/main/java/com/scalevision/backend/service/VideoService.java
+++ b/backend/src/main/java/com/scalevision/backend/service/VideoService.java
@@ -30,16 +30,25 @@ import java.util.UUID;
 public class VideoService {
 
     private final VideoRepository videoRepository;
-    private final Path uploadRoot;
+    private final Path storageRoot;
+    private final Path originalsDir;
+    private final Path finalsDir;
+    private final Path thumbnailsDir;
 
     public VideoService(
             VideoRepository videoRepository,
             @Value("${app.storage.upload-dir:uploads}") String uploadDir
     ) {
         this.videoRepository = videoRepository;
-        this.uploadRoot = Paths.get(uploadDir).toAbsolutePath().normalize();
+        this.storageRoot = Paths.get(uploadDir).toAbsolutePath().normalize();
+        this.originalsDir = storageRoot.resolve("originals");
+        this.finalsDir = storageRoot.resolve("finals");
+        this.thumbnailsDir = storageRoot.resolve("thumbnails");
         try {
-            Files.createDirectories(this.uploadRoot);
+            Files.createDirectories(this.storageRoot);
+            Files.createDirectories(this.originalsDir);
+            Files.createDirectories(this.finalsDir);
+            Files.createDirectories(this.thumbnailsDir);
         } catch (IOException ex) {
             throw new IllegalStateException("No se pudo crear el directorio de uploads", ex);
         }
@@ -73,7 +82,7 @@ public class VideoService {
         String nombreBase = limpiarNombreSinExtension(originalName);
         String storedFileName = System.currentTimeMillis() + "-" + UUID.randomUUID() + "." + formato;
 
-        Path destination = uploadRoot.resolve(storedFileName);
+        Path destination = originalsDir.resolve(storedFileName);
         try {
             Files.copy(videoFile.getInputStream(), destination, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException ex) {
@@ -92,7 +101,7 @@ public class VideoService {
         video.setRutaArchivoLocal(destination.toString());
 
         VideoPoc saved = videoRepository.save(video);
-        saved.setUrlVideoOriginal("http://localhost:8080/svmvp/uploads/" + storedFileName);
+        saved.setUrlVideoOriginal("http://localhost:8080/svmvp/uploads/originals/" + storedFileName);
         saved = videoRepository.save(saved);
 
         return new UploadVideoResponse(saved.getId(), saved.getUrlVideoOriginal(), saved.getEstado().name());
@@ -179,24 +188,34 @@ public class VideoService {
         if (video.getEstado() == VideoStatus.CORTANDO && seconds >= 4) {
             video.setEstado(VideoStatus.CORTADO);
             video.setFecha(LocalDateTime.now());
-            video.setUrlVideoOriginalCortado(buildFinalVideoUrl(video.getId()));
+            String finalFileName = generarArchivoFinal(video);
+            video.setRutaArchivoLocalFinal(finalsDir.resolve(finalFileName).toString());
+            video.setUrlVideoOriginalCortado(buildFinalVideoUrl(finalFileName));
             videoRepository.save(video);
         }
     }
 
     private void generarMiniVistas(VideoPoc video) {
-        video.setUrlMiniVista01("https://cdn.scalevision.local/videos/" + video.getId() + "/mini-1.jpg");
-        video.setUrlMiniVista02("https://cdn.scalevision.local/videos/" + video.getId() + "/mini-2.jpg");
-        video.setUrlMiniVista03("https://cdn.scalevision.local/videos/" + video.getId() + "/mini-3.jpg");
+        String mini1 = video.getId() + "-mini-1.jpg";
+        String mini2 = video.getId() + "-mini-2.jpg";
+        String mini3 = video.getId() + "-mini-3.jpg";
+
+        crearMiniVistaPlaceholder(mini1);
+        crearMiniVistaPlaceholder(mini2);
+        crearMiniVistaPlaceholder(mini3);
+
+        video.setUrlMiniVista01("http://localhost:8080/svmvp/uploads/thumbnails/" + mini1);
+        video.setUrlMiniVista02("http://localhost:8080/svmvp/uploads/thumbnails/" + mini2);
+        video.setUrlMiniVista03("http://localhost:8080/svmvp/uploads/thumbnails/" + mini3);
     }
 
     private String buildOriginalUrl(Long id, String nombre, String formato) {
         String safeNombre = nombre.toLowerCase().replace(" ", "-");
-        return "https://cdn.scalevision.local/videos/" + id + "/" + safeNombre + "." + formato;
+        return "http://localhost:8080/svmvp/uploads/originals/" + id + "-" + safeNombre + "." + formato;
     }
 
-    private String buildFinalVideoUrl(Long id) {
-        return "https://cdn.scalevision.local/videos/" + id + "/final-vertical.mp4";
+    private String buildFinalVideoUrl(String finalFileName) {
+        return "http://localhost:8080/svmvp/uploads/finals/" + finalFileName;
     }
 
     private String extraerExtension(String fileName) {
@@ -218,5 +237,35 @@ public class VideoService {
 
     private double convertirAMegaBytes(long bytes) {
         return Math.round((bytes / (1024.0 * 1024.0)) * 100.0) / 100.0;
+    }
+
+    private String generarArchivoFinal(VideoPoc video) {
+        String formato = video.getFormato() == null ? "mp4" : video.getFormato();
+        String finalFileName = video.getId() + "-final-" + System.currentTimeMillis() + "." + formato;
+        Path destination = finalsDir.resolve(finalFileName);
+
+        try {
+            if (video.getRutaArchivoLocal() != null && Files.exists(Paths.get(video.getRutaArchivoLocal()))) {
+                Files.copy(Paths.get(video.getRutaArchivoLocal()), destination, StandardCopyOption.REPLACE_EXISTING);
+            } else {
+                Files.writeString(destination, "VIDEO FINAL SIMULADO");
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("No se pudo guardar el video final en carpeta finals", ex);
+        }
+
+        return finalFileName;
+    }
+
+    private void crearMiniVistaPlaceholder(String fileName) {
+        Path destination = thumbnailsDir.resolve(fileName);
+        if (Files.exists(destination)) {
+            return;
+        }
+        try {
+            Files.writeString(destination, "MINI-VISTA");
+        } catch (IOException ex) {
+            throw new IllegalStateException("No se pudo guardar mini-vista en carpeta thumbnails", ex);
+        }
     }
 }


### PR DESCRIPTION
## Resumen
Se completa backend MVC para FE con subida real de video, storage local organizado y flujo de estados con polling.

## Incluye
- Endpoint upload en multipart/form-data:
  - `POST http://localhost:8080/svmvp/videos/subir`
- Endpoints FE de flujo:
  - `GET /videos/estado/{id}`
  - `GET /videos/mini-vistas/{id}`
  - `POST /videos/cortar-video/{id}`
  - `GET /videos/final/{id}`
- H2 + entidad `VideoPoc` actualizada
- Manejo de errores mejorado para FE/usuario
- Documentación actualizada con URLs completas

## Storage local (MVP)
- `uploads/originals/` (archivo original)
- `uploads/finals/` (video final)
- `uploads/thumbnails/` (mini-vistas)

## Validación
- `mvn test` OK
- Subida real de archivo validada por curl
