### PR TITLE
[BACKEND][MVC] Ajuste endpoint subir: file + modo_corte + metadatos opcionales

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -57,7 +57,8 @@ Lista rapida (URL completa):
 ## Flujo (polling)
 
 1. FE llama `POST http://localhost:8080/svmvp/videos/subir` (multipart/form-data con archivo).
-Campo multipart esperado: `file` + `modo_corte` (`face_tracking` o `center_crop`).
+Campos multipart: `file` + `modo_corte` (`face_tracking` o `center_crop`) y opcionalmente `nombre`, `tamano`, `formato`.
+Campos removidos: `nickname`, `duracion`.
 2. FE hace polling a `GET http://localhost:8080/svmvp/videos/estado/{id}` cada 3-5s.
 3. Cuando llega a `PROCESADO`, FE consulta `GET http://localhost:8080/svmvp/videos/mini-vistas/{id}`.
 4. FE envía mini-vista elegida con `POST http://localhost:8080/svmvp/videos/cortar-video/{id}`.

--- a/backend/docs/API_CONTRACT_FE.md
+++ b/backend/docs/API_CONTRACT_FE.md
@@ -14,13 +14,24 @@ Request (`multipart/form-data`):
 - `modo_corte`: texto obligatorio con valores:
   - `face_tracking`
   - `center_crop`
+- `nombre`: texto opcional
+- `tamano`: numero decimal opcional
+- `formato`: texto opcional (ejemplo: `MP4`)
+
+Campos eliminados del contrato:
+
+- `nickname`
+- `duracion`
 
 Ejemplo terminal:
 
 ```bash
 curl -X POST "http://localhost:8080/svmvp/videos/subir" \
   -F "file=@/ruta/demo.mp4" \
-  -F "modo_corte=face_tracking"
+  -F "modo_corte=face_tracking" \
+  -F "nombre=video_demo_scalevision" \
+  -F "tamano=15.7" \
+  -F "formato=MP4"
 ```
 
 Response `201`:

--- a/backend/src/main/java/com/scalevision/backend/controller/VideoController.java
+++ b/backend/src/main/java/com/scalevision/backend/controller/VideoController.java
@@ -4,7 +4,6 @@ import com.scalevision.backend.dto.CortarVideoRequest;
 import com.scalevision.backend.dto.CortarVideoResponse;
 import com.scalevision.backend.dto.EstadoVideoResponse;
 import com.scalevision.backend.dto.MiniVistasResponse;
-import com.scalevision.backend.dto.UploadVideoRequest;
 import com.scalevision.backend.dto.UploadVideoResponse;
 import com.scalevision.backend.dto.VideoFinalResponse;
 import com.scalevision.backend.service.VideoService;
@@ -31,17 +30,16 @@ public class VideoController {
         this.videoService = videoService;
     }
 
-    @PostMapping(value = "/subir", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<UploadVideoResponse> subirVideo(@Valid @RequestBody UploadVideoRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(videoService.subirVideo(request));
-    }
-
     @PostMapping(value = "/subir", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UploadVideoResponse> subirVideoArchivo(
             @RequestParam("file") MultipartFile file,
-            @RequestParam("modo_corte") String modoCorte
+            @RequestParam("modo_corte") String modoCorte,
+            @RequestParam(value = "nombre", required = false) String nombre,
+            @RequestParam(value = "tamano", required = false) Double tamano,
+            @RequestParam(value = "formato", required = false) String formato
     ) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(videoService.subirVideoArchivo(file, modoCorte));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(videoService.subirVideoArchivo(file, modoCorte, nombre, tamano, formato));
     }
 
     @GetMapping("/estado/{id}")

--- a/backend/src/main/java/com/scalevision/backend/service/VideoService.java
+++ b/backend/src/main/java/com/scalevision/backend/service/VideoService.java
@@ -74,16 +74,25 @@ public class VideoService {
         return new UploadVideoResponse(saved.getId(), saved.getUrlVideoOriginal(), saved.getEstado().name());
     }
 
-    public UploadVideoResponse subirVideoArchivo(MultipartFile videoFile, String modoCorteRaw) {
+    public UploadVideoResponse subirVideoArchivo(
+            MultipartFile videoFile,
+            String modoCorteRaw,
+            String nombre,
+            Double tamano,
+            String formato
+    ) {
         if (videoFile == null || videoFile.isEmpty()) {
             throw new BadRequestException("Debe enviar un archivo de video");
         }
         ModoCorte modoCorte = ModoCorte.fromValue(modoCorteRaw);
 
         String originalName = videoFile.getOriginalFilename() == null ? "video.mp4" : videoFile.getOriginalFilename();
-        String formato = extraerExtension(originalName);
+        String formatoArchivo = extraerExtension(originalName);
         String nombreBase = limpiarNombreSinExtension(originalName);
-        String storedFileName = System.currentTimeMillis() + "-" + UUID.randomUUID() + "." + formato;
+        String formatoFinal = (formato == null || formato.isBlank()) ? formatoArchivo : formato.toLowerCase(Locale.ROOT);
+        String nombreFinal = (nombre == null || nombre.isBlank()) ? nombreBase : nombre.trim();
+        double tamanoFinal = tamano == null ? convertirAMegaBytes(videoFile.getSize()) : tamano;
+        String storedFileName = System.currentTimeMillis() + "-" + UUID.randomUUID() + "." + formatoArchivo;
 
         Path destination = originalsDir.resolve(storedFileName);
         try {
@@ -93,10 +102,10 @@ public class VideoService {
         }
 
         VideoPoc video = new VideoPoc();
-        video.setNombre(nombreBase);
+        video.setNombre(nombreFinal);
         video.setNickname(null);
-        video.setTamano(convertirAMegaBytes(videoFile.getSize()));
-        video.setFormato(formato);
+        video.setTamano(tamanoFinal);
+        video.setFormato(formatoFinal);
         video.setDuracion(60);
         video.setModoCorte(modoCorte.getValue());
         video.setEstado(VideoStatus.SUBIDO);


### PR DESCRIPTION
## Resumen
Se actualiza el contrato del endpoint de subida para alinearlo con FE.

## Cambios principales
- Endpoint:
  - `POST http://localhost:8080/svmvp/videos/subir`
- Request ahora en `multipart/form-data` con:
  - `file` (obligatorio)
  - `modo_corte` (obligatorio: `face_tracking` o `center_crop`)
  - `nombre` (opcional)
  - `tamano` (opcional)
  - `formato` (opcional)
- Se eliminan del contrato de subida:
  - `nickname`
  - `duracion`

## Backend
- Validación de `modo_corte` con enum.
- Persistencia en H2 de `modo_corte`.
- Flujo de almacenamiento local por carpetas:
  - `uploads/originals/`
  - `uploads/finals/`
  - `uploads/thumbnails/`

## Documentación actualizada
- `backend/docs/API_CONTRACT_FE.md`
- `backend/README.md`
- `backend/docs/H2_DATABASE.md`

## Validación
- `mvn test` OK
- pruebas manuales de upload multipart OK
