### PR TITLE
feat(api): migrar a HTTP/2, habilitar CORS y estandarizar tipos de da…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN mkdir -p /app/scalevision_data/originals \
 EXPOSE 8000
 
 # 9. Comando de arranque del servidor (Sin --reload para producción)
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["hypercorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docs/historial_cambios.md
+++ b/docs/historial_cambios.md
@@ -73,3 +73,8 @@ Este log documenta la evolución del motor de IA hasta alcanzar el grado de prod
    * **Objetivo:** Iniciar el video exactamente cuando el protagonista es el foco de la acción, ignorando su presencia en el fondo.
    * **Incidencia:** El rastreador detectaba al sujeto en el frame 0, pero solo mostraba un hombro en el borde o estaba a 50 metros de distancia, generando segundos de tiempo muerto visual.
    * **Resolución:** Inyección de *Heurística de Bordes* (ignorar detecciones a < 10px de los márgenes) y *Regla de Relevancia Espacial* (el sujeto debe alcanzar el 50% de su área máxima para gatillar el `start_frame`).
+
+9. **Validación de Protocolo y Contrato REST (Integración MVC)**
+   * **Objetivo:** Habilitar multiplexación de red y garantizar la compatibilidad estricta de tipos de datos con el Backend (Java Spring Boot) y Frontend.
+   * **Incidencia:** El servidor base (`uvicorn`) bloqueaba el tráfico concurrente pesado (HTTP/1.1), y el uso del tipo `HttpUrl` (Pydantic) generaba objetos serializados incompatibles con las validaciones de String plano del consumidor.
+   * **Resolución:** Migración del motor ASGI a **Hypercorn** para soporte nativo HTTP/2. Refactorización de todos los DTOs (`models.py`) a tipos primitivos (`str`), y adición del middleware CORS para *bypass* de seguridad en demostraciones locales.

--- a/models.py
+++ b/models.py
@@ -5,7 +5,7 @@ from uuid import UUID
 # Phase 1: Scan
 class ScanRequest(BaseModel):
     id: UUID
-    video_url: HttpUrl
+    video_url: str
     modo_corte: Optional[Literal["face_tracking", "center_crop"]] = "face_tracking"
 
 # Phase 2: Process
@@ -13,8 +13,7 @@ class ProcessRequest(BaseModel):
     id: UUID
     target_subject_id: Optional[str] = None
     strategy: Literal["face_tracking", "center_crop"]
-
-# Common Metadata
+    webhook_url: Optional[str] = None
 class ScanMetadata(BaseModel):
     processing_time_ms: int
     video_duration_seconds: float
@@ -27,5 +26,5 @@ class Subject(BaseModel):
 
 class Fallback(BaseModel):
     is_active: bool
-    strategy: Optional[Literal["CENTER_CROP"]] = None
+    strategy: Optional[Literal["center_crop"]] = None
     reason: Optional[str] = None

--- a/modules/orquestador.py
+++ b/modules/orquestador.py
@@ -71,7 +71,7 @@ class ScaleVisionPipeline:
                     }
                 )
         else:
-            print("WARNING: Ningún sujeto alcanzó el 70% de aparición.")
+            print("WARNING: Ningún sujeto alcanzó el 40% de aparición.")
             response["fallback"] = {
                 "is_active": True,
                 "strategy": "center_crop",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Servidor y API REST
 fastapi
-uvicorn
+hypercorn
 python-multipart
 
 # Core de IA y Visión Computacional


### PR DESCRIPTION
…tos REST

- Reemplazar Uvicorn por Hypercorn como servidor ASGI para habilitar multiplexación nativa vía HTTP/2.
- Refactorizar esquemas Pydantic ('models.py'): cambiar 'HttpUrl' a primitivo 'str' para evitar conflictos de parseo de objetos con el backend MVC (Java).
- Inyectar campo 'webhook_url' faltante en ProcessRequest para asegurar el flujo asíncrono.
- Configurar middleware CORS en 'main.py' para permitir peticiones directas desde el Frontend durante demostraciones controladas.
- Limpiar importaciones huérfanas en modelos de datos.